### PR TITLE
[YUNIKORN-1175] Web UI should show node utilization as percentage

### DIFF
--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -194,7 +194,7 @@ export class SchedulerService {
               this.formatResource(node['allocated'] as SchedulerResourceInfo),
               this.formatResource(node['occupied'] as SchedulerResourceInfo),
               this.formatResource(node['available'] as SchedulerResourceInfo),
-              this.formatResource(node['utilized'] as SchedulerResourceInfo),
+              this.formatPercent(node['utilized'] as SchedulerResourceInfo),
               []
             );
 
@@ -309,6 +309,24 @@ export class SchedulerService {
 
     if (resource && resource.vcore !== undefined) {
       formatted.push(`CPU: ${CommonUtil.formatCount(resource.vcore)}`);
+    } else {
+      formatted.push(`CPU: ${NOT_AVAILABLE}`);
+    }
+
+    return formatted.join(', ');
+  }
+
+  private formatPercent(resource: SchedulerResourceInfo): string {
+    const formatted = [];
+
+    if (resource && resource.memory !== undefined) {
+      formatted.push(`Memory: ${CommonUtil.formatPercent(resource.memory)}`);
+    } else {
+      formatted.push(`Memory: ${NOT_AVAILABLE}`);
+    }
+
+    if (resource && resource.vcore !== undefined) {
+      formatted.push(`CPU: ${CommonUtil.formatPercent(resource.vcore)}`);
     } else {
       formatted.push(`CPU: ${NOT_AVAILABLE}`);
     }

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -62,7 +62,7 @@ export class CommonUtil {
   }
 
   static formatPercent(value: number | string): string {
-    let toValue = +value;
+    const toValue = +value;
     return `${toValue.toFixed(0)}%`;
   }
 

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -61,6 +61,11 @@ export class CommonUtil {
     return `${toValue.toFixed(1)} ${unit}`;
   }
 
+  static formatPercent(value: number | string): string {
+    let toValue = +value;
+    return `${toValue.toFixed(0)}%`;
+  }
+
   static isEmpty(arg: object | any[]): boolean {
     return Object.keys(arg).length === 0;
   }


### PR DESCRIPTION
### What is this PR for?
Updates the web UI to show node utilization column as a percentage.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1175

### How should this be tested?

### Screenshots (if appropriate)
<img width="206" alt="utilization" src="https://user-images.githubusercontent.com/12699633/162791241-443a7896-bff9-46d1-82a1-7be9fc9e72f1.png">

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
