### PR TITLE
[YUNIKORN-1257] docker build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,34 +16,35 @@
 # limitations under the License.
 
 ARG ARCH=
+ARG NODE_VERSION=
 # Buildstage: use the local architecture
-FROM node:16.14.2-alpine3.15 as buildstage
+FROM node:${NODE_VERSION}-alpine as buildstage
 
-WORKDIR /usr/uiapp
-
-COPY . .
-
-RUN rm -rf ./dist
+WORKDIR /work
+# Only copy what is needed for the build
+COPY *.json *.js yarn.lock .browserslistrc /work/
+COPY src /work/src/
 
 RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 yarn install
-
 RUN yarn build:prod
 
 # Imagestage: use the requested architecture
-FROM ${ARCH}nginx:1.21.4-alpine
+FROM ${ARCH}nginx:1.22-alpine
 
-COPY --from=buildstage /usr/uiapp/dist/yunikorn-web /usr/share/nginx/html
+# Home location for all data and configs
+ENV HOME=/opt/yunikorn
+EXPOSE 9889
 
-COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+# Always run everything as yunikorn
+RUN addgroup -S -g 4444 yunikorn && \
+    adduser -S -h $HOME -G yunikorn -u 4444 yunikorn -s /bin/sh && \
+    mkdir -p $HOME && \
+    chown -R 4444:0 $HOME && \
+    chmod -R g=u $HOME
 
-RUN mkdir -p /opt/nginx/work && \
-    chown -R nginx:nginx /opt/nginx/work && \
-    chmod 755 /opt/nginx/work && \
-    mkdir -p /var/cache/nginx /var/log/nginx && \
-    chown -R nginx:nginx /var/cache/nginx /var/log/nginx && \
-    sed -i 's_^user .*$__' /etc/nginx/nginx.conf && \
-    sed -i 's_^pid .*$_pid /opt/nginx/work/nginx.pid;_' /etc/nginx/nginx.conf
+COPY --chown=4444:0 ./nginx/nginx.conf $HOME/
+COPY --chown=4444:0 --from=buildstage /work/dist/yunikorn-web $HOME/html/
 
-WORKDIR /opt/nginx/work
-USER nginx
-ENTRYPOINT [ "nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
+WORKDIR $HOME
+USER yunikorn
+ENTRYPOINT nginx -c $HOME/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ ENV HOME=/opt/yunikorn
 EXPOSE 9889
 
 # Always run everything as yunikorn
-RUN addgroup -S -g 4444 yunikorn && \
+RUN mkdir -p $HOME && \
+    addgroup -S -g 4444 yunikorn && \
     adduser -S -h $HOME -G yunikorn -u 4444 yunikorn -s /bin/sh && \
-    mkdir -p $HOME && \
     chown -R 4444:0 $HOME && \
     chmod -R g=u $HOME
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,14 +1,51 @@
-server {
-  listen 9889;
-  location / {
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-    try_files $uri $uri/ /index.html;
-  }
-  location /ws {
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_pass http://127.0.0.1:9080;
-  }
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+worker_processes  auto;
+daemon            off;
+error_log         /tmp/nginx-error.log error;
+pid               /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include               /etc/nginx/mime.types;
+    default_type          application/octet-stream;
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+    sendfile              on;
+    keepalive_timeout     65;
+    access_log            off;
+    server {
+        listen 9889;
+        location / {
+            root /opt/yunikorn/html;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
+        location /ws {
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass http://127.0.0.1:9080;
+        }
+    }
 }


### PR DESCRIPTION
### What is this PR for?
Move to a self-contained nginx.conf file. Removes the chance of picking
up unwanted settings from the default config. This config includes:
- daemon mode is turned off
- all caches moved to /tmp
- error log and pid file moved to /tmp
- access logging is turned off
Build optimisation with reduced data copies and image layers.

Incorporates Openshift dynamic user support.

This file requires YUNIKORN-1258 for node version propagation to be
complete.

### What type of PR is it?
* [X] - Bug Fix
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1257

### How should this be tested?
Image build must still provide working image, tested locally

