### PR TITLE
[YUNIKORN-1290] DOCKER_ARCH is empty when executing command "make image" on arm64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ else ifneq (,$(filter $(HOST_ARCH), arm64 aarch64))
 DOCKER_ARCH := arm64v8
 else ifeq (armv7l, $(HOST_ARCH))
 DOCKER_ARCH := arm32v7
+else
+DOCKER_ARCH := amd64
 endif
 
 WEB_SHA=$$(git rev-parse --short=12 HEAD)

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ clean:
 .PHONY: image
 NODE_VERSION := $(shell cat .nvmrc)
 image:
-	@echo "Building web UI docker image:${DOCKER_ARCH}"
+	@echo "Building web UI docker image"
 	docker build -t ${REGISTRY}/yunikorn:web-${DOCKER_ARCH}-${VERSION} . \
 	--label "yunikorn-web-revision=$${WEB_SHA}" \
 	--label "Version=${VERSION}" \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifeq (x86_64, $(HOST_ARCH))
 DOCKER_ARCH := amd64
 else ifeq (i386, $(HOST_ARCH))
 DOCKER_ARCH := i386
-else ifeq (aarch64, $(HOST_ARCH))
+else ifneq (,$(filter $(HOST_ARCH), arm64 aarch64))
 DOCKER_ARCH := arm64v8
 else ifeq (armv7l, $(HOST_ARCH))
 DOCKER_ARCH := arm32v7
@@ -111,7 +111,7 @@ clean:
 .PHONY: image
 NODE_VERSION := $(shell cat .nvmrc)
 image:
-	@echo "Building web UI docker image"
+	@echo "Building web UI docker image:${DOCKER_ARCH}"
 	docker build -t ${REGISTRY}/yunikorn:web-${DOCKER_ARCH}-${VERSION} . \
 	--label "yunikorn-web-revision=$${WEB_SHA}" \
 	--label "Version=${VERSION}" \


### PR DESCRIPTION
### What is this PR for?
DOCKER_ARCH is empty when executing "make image" in arm64 environment.
This commit follows the Makefile in K8shim. The architecture is filtered by the filter command.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1290

### How should this be tested?
Executing the "make image" command in Yunikorn-web rep would build apache/yunikorn:web-arm64v8-latest image.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
