### PR TITLE
[YUNIKORN-1479] Yunikorn Dashboard fa-question link got broken

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -80,7 +80,7 @@
           <mat-menu #helpMenu="matMenu" xPosition="before">
             <button mat-menu-item (click)="openYuniKornHelp('/')">Apache YuniKorn</button>
             <button mat-menu-item (click)="openYuniKornHelp('/docs')">Documentation</button>
-            <button mat-menu-item (click)="openYuniKornHelp('/community/sessions')">
+            <button mat-menu-item (click)="openYuniKornHelp('/community/events')">
               Sessions and Demos
             </button>
             <button mat-menu-item (click)="openYuniKornHelp('/community/get_involved')">


### PR DESCRIPTION
### What is this PR for?
Yunikorn Dashboard UI, Help icon link got broken, 
currently pointing to https://yunikorn.apache.org/community/events/sessions
After this PR it redirects to the correct page https://yunikorn.apache.org/community/events

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1479

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
