### PR TITLE
[YUNIKORN-108] Only memory and vcore is displayed on the web UI

### DIFF
--- a/json-db.json
+++ b/json-db.json
@@ -31,7 +31,10 @@
       "hugepages-64Ki": 0,
       "memory": 4110970880,
       "pods": 110,
-      "vcore": 2000
+      "vcore": 2000,
+      "nvidia.com/gpu": 10,
+      "amd.com/gpu": 10,
+      "gpu.intel.com/i915": 10
     },
     "guaranteedResource": {},
     "allocatedResource": {
@@ -65,11 +68,13 @@
         "pendingResource": {},
         "maxResource": {
           "memory": 300000000,
-          "vcore": 300
+          "vcore": 300,
+          "nvidia.com/gpu": 10
         },
         "guaranteedResource": {
           "memory": 200000000,
-          "vcore": 200
+          "vcore": 200,
+          "nvidia.com/gpu": 10
         },
         "allocatedResource": {
           "memory": 270000000,
@@ -98,11 +103,13 @@
         "pendingResource": {},
         "maxResource": {
           "memory": 300000000,
-          "vcore": 300
+          "vcore": 300,
+          "amd.com/gpu": 10
         },
         "guaranteedResource": {
           "memory": 200000000,
-          "vcore": 200
+          "vcore": 200,
+          "amd.com/gpu": 10
         },
         "allocatedResource": {},
         "preemptingResource": {},
@@ -165,11 +172,13 @@
         "pendingResource": {},
         "maxResource": {
           "memory": 100000000,
-          "vcore": 100
+          "vcore": 100,
+          "gpu.intel.com/i915": 10
         },
         "guaranteedResource": {
           "memory": 100000000,
-          "vcore": 100
+          "vcore": 100,
+          "gpu.intel.com/i915": 10
         },
         "allocatedResource": {
           "memory": 80000000,

--- a/src/app/models/resource-info.model.ts
+++ b/src/app/models/resource-info.model.ts
@@ -19,9 +19,15 @@
 export interface ResourceInfo {
   memory: string;
   vcore: string;
+  "nvidia.com/gpu": string;
+  "amd.com/gpu": string;
+  "gpu.intel.com/i915": string;
 }
 
 export interface SchedulerResourceInfo {
   memory: number;
   vcore: number;
+  "nvidia.com/gpu": number;
+  "amd.com/gpu": number;
+  "gpu.intel.com/i915": number;
 }

--- a/src/app/models/resource-info.model.ts
+++ b/src/app/models/resource-info.model.ts
@@ -19,15 +19,11 @@
 export interface ResourceInfo {
   memory: string;
   vcore: string;
-  "nvidia.com/gpu": string;
-  "amd.com/gpu": string;
-  "gpu.intel.com/i915": string;
+  [key: string]: string;
 }
 
 export interface SchedulerResourceInfo {
   memory: number;
   vcore: number;
-  "nvidia.com/gpu": number;
-  "amd.com/gpu": number;
-  "gpu.intel.com/i915": number;
+  [key: string]: number;
 }

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -318,7 +318,7 @@ export class SchedulerService {
     const formatted = [];
 
     if (resource && resource.memory !== undefined) {
-      formatted.push(`Memory: ${CommonUtil.formatMemory(resource.memory)}`);
+      formatted.push(`Memory: ${CommonUtil.formatBytes(resource.memory)}`);
     } else {
       formatted.push(`Memory: ${NOT_AVAILABLE}`);
     }
@@ -329,16 +329,23 @@ export class SchedulerService {
       formatted.push(`CPU: ${NOT_AVAILABLE}`);
     }
 
-    if (resource && resource["nvidia.com/gpu"] !== undefined) {
-      formatted.push(`nvidia.com/gpu: ${CommonUtil.formatGpu(resource["nvidia.com/gpu"])}`);
-    }
-
-    if (resource && resource["amd.com/gpu"] !== undefined) {
-      formatted.push(`amd.com/gpu: ${CommonUtil.formatGpu(resource["amd.com/gpu"])}`);
-    }
-
-    if (resource && resource["gpu.intel.com/i915"] !== undefined) {
-      formatted.push(`gpu.intel.com/i915: ${CommonUtil.formatGpu(resource["gpu.intel.com/i915"])}`);
+    if (resource){
+      Object.keys(resource).forEach((key) => {
+        switch(key){
+          case "memory":
+          case "vcore":{
+            break;
+          }
+          case "ephemeral-storage":{
+            formatted.push(`ephemeral-storage: ${CommonUtil.formatBytes(resource[key])}`);
+            break;
+          }
+          default:{
+            formatted.push(`${key}: ${CommonUtil.formatOtherResource(resource[key])}`);
+            break;
+          }
+        }
+      });
     }
     
     return formatted.join(', ');

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -329,6 +329,18 @@ export class SchedulerService {
       formatted.push(`CPU: ${NOT_AVAILABLE}`);
     }
 
+    if (resource && resource["nvidia.com/gpu"] !== undefined) {
+      formatted.push(`nvidia.com/gpu: ${CommonUtil.formatGpu(resource["nvidia.com/gpu"])}`);
+    }
+
+    if (resource && resource["amd.com/gpu"] !== undefined) {
+      formatted.push(`amd.com/gpu: ${CommonUtil.formatGpu(resource["amd.com/gpu"])}`);
+    }
+
+    if (resource && resource["gpu.intel.com/i915"] !== undefined) {
+      formatted.push(`gpu.intel.com/i915: ${CommonUtil.formatGpu(resource["gpu.intel.com/i915"])}`);
+    }
+    
     return formatted.join(', ');
   }
 

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -337,11 +337,19 @@ export class SchedulerService {
             break;
           }
           case "ephemeral-storage":{
-            formatted.push(`ephemeral-storage: ${CommonUtil.formatBytes(resource[key])}`);
+            if (resource[`ephemeral-storage`] == 0) {
+              formatted.push(`ephemeral-storage: ${NOT_AVAILABLE}`);
+            }else{
+              formatted.push(`ephemeral-storage: ${CommonUtil.formatBytes(resource[key])}`);
+            }
             break;
           }
           default:{
-            formatted.push(`${key}: ${CommonUtil.formatOtherResource(resource[key])}`);
+            if (resource[key] == 0) {
+              formatted.push(`${key}: ${NOT_AVAILABLE}`);
+            }else{
+              formatted.push(`${key}: ${CommonUtil.formatOtherResource(resource[key])}`);
+            }
             break;
           }
         }

--- a/src/app/utils/common.util.spec.ts
+++ b/src/app/utils/common.util.spec.ts
@@ -23,16 +23,16 @@ describe('CommonUtil', () => {
     expect(CommonUtil.createUniqId).toBeTruthy();
   });
 
-  it('should have formatMemory method', () => {
-    expect(CommonUtil.formatMemory).toBeTruthy();
+  it('should have formatBytes method', () => {
+    expect(CommonUtil.formatBytes).toBeTruthy();
   });
 
-  it('checking formatMemory method result', () => {
+  it('checking formatBytes method result', () => {
     var inputs: number[] = [100, 1100, 1200000, 1300000000, 1400000000000, 1500000000000000];
     var expected: string[] = ['100.0 bytes', '1.1 KB', '1.2 MB', '1.3 GB', '1.4 TB', '1.5 PB'];
     for (var index: number = 0, len = inputs.length; index < len; index = index + 1) {
-      expect(CommonUtil.formatMemory(inputs[index])).toEqual(expected[index]);
-      expect(CommonUtil.formatMemory(inputs[index].toString())).toEqual(expected[index]);
+      expect(CommonUtil.formatBytes(inputs[index])).toEqual(expected[index]);
+      expect(CommonUtil.formatBytes(inputs[index].toString())).toEqual(expected[index]);
     }
   });
 });

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -48,11 +48,15 @@ export class CommonUtil {
   static formatCount(value: number | string): string {
     const unit = 'K';
     const toValue = +value;
-
     if (toValue >= 10000) {
       return `${(toValue / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })} ${unit}`;
     }
 
+    return toValue.toLocaleString();
+  }
+
+  static formatGpu(value: number | string): string {
+    const toValue = +value;
     return toValue.toLocaleString();
   }
 

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -30,7 +30,7 @@ export class CommonUtil {
     return uniqid;
   }
 
-  static formatMemory(value: number | string): string {
+  static formatBytes(value: number | string): string {
     const units: readonly string[] = ['KB', 'MB', 'GB', 'TB', 'PB'];
     var unit: string = 'bytes';
     let toValue = +value
@@ -55,7 +55,7 @@ export class CommonUtil {
     return toValue.toLocaleString();
   }
 
-  static formatGpu(value: number | string): string {
+  static formatOtherResource(value: number | string): string {
     const toValue = +value;
     return toValue.toLocaleString();
   }


### PR DESCRIPTION
### What is this PR for?
The WebUI currently displays only "vcore" and "memory" resources. To improve flexibility, I added a new parameter to the SchedulerResourceInfo interface, enabling dynamic retrieval of various resource types. This allows the WebUI to display different resources based on requirements.

Additionally, I included GPU resources from three vendors in db.json to demonstrate handling diverse resource types in the WebUI.

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-108/

### How should this be tested?

### Screenshots (if appropriate)
![image](https://github.com/apache/yunikorn-web/assets/48400525/fe6f2a6a-a1c0-4f4e-9007-a113c5ae8aa7)
![image](https://github.com/apache/yunikorn-web/assets/48400525/7951a9f5-c23e-45c0-a1a2-859a2464bd30)
![image](https://github.com/apache/yunikorn-web/assets/48400525/ae2ac480-2767-4780-b5c3-2470fa4ce0a9)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
