### PR TITLE
[YUNIKORN-1860] fix totalContainers

### DIFF
--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -86,6 +86,7 @@ export class DashboardComponent implements OnInit {
           ? list[0].nodeSortingPolicy.type
           : NOT_AVAILABLE;
 
+        list[0].totalContainers = list[0].totalContainers || 0;
         this.partitionName = list[0].name || NOT_AVAILABLE;
         this.totalNodes = String(list[0].totalNodes);
         this.totalApplications = String(list[0].applications.total);


### PR DESCRIPTION
### What is this PR for?

After we add `omitempty`, we miss `TotalContainers` in `/ws/v1/partitions`. Add a default value to fix it.

<img width="1073" alt="Screenshot 2023-08-02 at 1 30 09 PM" src="https://github.com/apache/yunikorn-web/assets/4927361/d0105124-ca12-46a7-8cdb-83a6b37c9446">


### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-1860

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
