### PR TITLE
[YUNIKORN-1924] Last time app changed is always n/a

### DIFF
--- a/src/app/components/apps-view/apps-view.component.html
+++ b/src/app/components/apps-view/apps-view.component.html
@@ -70,6 +70,10 @@
           <mat-cell *matCellDef="let element">{{ element['formattedSubmissionTime'] }}</mat-cell>
         </ng-container>
 
+        <ng-container *ngIf="columnDef.colId === 'lastStateChangeTime'; else renderNext_1">
+          <mat-cell *matCellDef="let element">{{ element['formattedlastStateChangeTime'] }}</mat-cell>
+        </ng-container>
+
         <ng-template #renderNext_1>
           <ng-container *ngIf="columnDef.colId === 'usedResource'; else renderNext_1">
             <mat-cell *matCellDef="let element">

--- a/src/app/models/app-info.model.ts
+++ b/src/app/models/app-info.model.ts
@@ -31,6 +31,7 @@ export class AppInfo {
     public queueName: string,
     public submissionTime: number,
     public finishedTime: null | number,
+    public stateLog: Array<StateLog>,
     public lastStateChangeTime: null | number,
     public applicationState: string,
     public allocations: AllocationInfo[] | null
@@ -38,6 +39,14 @@ export class AppInfo {
 
   get formattedSubmissionTime() {
     const millisecs = Math.round(this.submissionTime / (1000 * 1000));
+    return moment(millisecs).format('YYYY/MM/DD HH:mm:ss');
+  }
+
+  get formattedlastStateChangeTime() {
+    if(this.lastStateChangeTime==null){
+      return 'n/a'
+    }
+    const millisecs = Math.round(this.lastStateChangeTime! / (1000 * 1000));
     return moment(millisecs).format('YYYY/MM/DD HH:mm:ss');
   }
 
@@ -53,4 +62,21 @@ export class AppInfo {
   setAllocations(allocs: AllocationInfo[]) {
     this.allocations = allocs;
   }
+
+  setLastStateChangeTime() {
+    let time=0
+    this.stateLog.forEach(log => {
+      if (log.time>time){
+        time=log.time
+      }
+    });
+    this.lastStateChangeTime=time
+  }
+}
+
+export class StateLog{
+  constructor(
+    public time: number,
+    public applicationState: string
+  ) {}
 }

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -96,10 +96,13 @@ export class SchedulerService {
               app['queueName'],
               app['submissionTime'],
               app['lastStateChangeTime'],
+              app['stateLog'],
               app['finishedTime'],
               app['applicationState'],
               []
             );
+            appInfo.setLastStateChangeTime()
+            
             const allocations = app['allocations'];
             if (allocations && allocations.length > 0) {
               const appAllocations: AllocationInfo[] = [];


### PR DESCRIPTION
### What is this PR for?
Integrate the stateLog into the appInfo dataset, and retrieve the lastStateChangeTime from it. 
Afterwards, ensure that the last State Change Time is visible on the web application.

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-1924/
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
