### PR TITLE
[YUNIKORN-74] Handle Negative Counters

### DIFF
--- a/json-db.json
+++ b/json-db.json
@@ -562,6 +562,18 @@
     {
       "timestamp": 1683692783389687867,
       "totalApplications": "5"
+    },
+    {
+      "timestamp": 1683692843389687867,
+      "totalApplications": "-1"
+    },
+    {
+      "timestamp": 1683692903389687867,
+      "totalApplications": "3"
+    },
+    {
+      "timestamp": 1683692963389687867,
+      "totalApplications": "5"
     }
   ],
   "containerHistory": [

--- a/src/app/components/area-chart/area-chart.component.ts
+++ b/src/app/components/area-chart/area-chart.component.ts
@@ -117,6 +117,9 @@ export class AreaChartComponent implements OnInit, AfterViewInit, OnChanges, OnD
       this.areaChart.destroy();
     }
 
+    // Filter out negative values from chartData
+    chartData = chartData.filter(item => item.y >= 0);
+
     this.areaChart = new Chart(ctx!, {
       type: 'line',
       data: {


### PR DESCRIPTION
### What is this PR for?
The REST API returns a -1 for all values that could not be converted from the internal prometheus counter to an integer. 
The webapp doesn't handle this gracefully and graph shows negative values on app counters which isn't possible.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [] - Task

### What is the Jira issue?
[YUNIKORN-74](https://issues.apache.org/jira/browse/YUNIKORN-74)

### How should this be tested?
I have added a negative counter in sample json file for testing. It is omitting the negative counter.

### Screenshots (if appropriate)
<img width="1317" alt="Screenshot 2023-10-20 at 3 24 05 PM" src="https://github.com/apache/yunikorn-web/assets/64547846/f486d1a2-b461-4dcf-93c1-f75eacc252dd">


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
