### PR TITLE
[YUNIKORN-1982] Enable manual triggering for GitHub CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
### What is this PR for?
Allow running manually from the github ui.
Everyone can manually run the CI on their fork.

github docs

https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-1982](https://issues.apache.org/jira/browse/YUNIKORN-1982)

### Screenshots (if appropriate)
Similar to the Apache/Spark benchmark GitHub action, anyone who forks the [yunikorn-web](https://github.com/apache/yunikorn-web) repository can execute tests on their own fork. This offers several benefits:

1. Increased confidence in pull requests.
2. Enhanced code quality through improved performance and stability.



This is a pr followed 
[yunikorn-core 681](https://github.com/apache/yunikorn-core/pull/681)
[yunikorn-site  336](https://github.com/apache/yunikorn-site/pull/336)
[yunikorn-k8shim 706](https://github.com/apache/yunikorn-k8shim/pull/706)

@craigcondit @pbacsko Please take a look !


