### PR TITLE
[YUNIKORN-2084] Remove = in web dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NODE_VERSION=
+ARG NODE_VERSION
 # Buildstage: use the local architecture
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine as buildstage
 


### PR DESCRIPTION
### What is this PR for?
The web Dockerfile contains an extra equal sign that should not be there:
`ARG NODE_VERSION= `


### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2084