### PR TITLE
[YUNIKORN-2140] Improve presentation of resource units in YuniKorn UI

### DIFF
--- a/src/app/services/scheduler/scheduler.service.spec.ts
+++ b/src/app/services/scheduler/scheduler.service.spec.ts
@@ -20,25 +20,84 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {TestBed} from '@angular/core/testing';
 import {EnvconfigService} from '@app/services/envconfig/envconfig.service';
 import {MockEnvconfigService} from '@app/testing/mocks';
-import {configureTestSuite} from 'ng-bullet';
 
 import {SchedulerService} from './scheduler.service';
+import {SchedulerResourceInfo} from '@app/models/resource-info.model';
+import {NOT_AVAILABLE} from '@app/utils/constants';
 
 describe('SchedulerService', () => {
   let service: SchedulerService;
 
-  configureTestSuite(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [SchedulerService, { provide: EnvconfigService, useValue: MockEnvconfigService }],
     });
-  });
-
-  beforeEach(() => {
     service = TestBed.inject(SchedulerService);
   });
 
   it('should create the service', () => {
     expect(service).toBeTruthy();
+    
+  });
+
+  it('should format SchedulerResourceInfo correctly', () => {
+    type TestCase = {
+      description: string;
+      schedulerResourceInfo: SchedulerResourceInfo;
+      expected: string;
+    };
+  
+    const testCases: TestCase[] = [
+      {
+        description: 'test simple resourceInfo',
+        schedulerResourceInfo: {
+          memory: 1024,
+          vcore: 2,
+        },
+        expected: 'Memory: 1 KiB, CPU: 2m'
+      },
+      {
+        description: 'test undefined resourceInfo',
+        schedulerResourceInfo : undefined as any,
+        expected: `Memory: ${NOT_AVAILABLE}, CPU: ${NOT_AVAILABLE}`
+      },
+      {
+        description: 'test empty resourceInfo',
+        schedulerResourceInfo : {} as any,
+        expected: `Memory: ${NOT_AVAILABLE}, CPU: ${NOT_AVAILABLE}`
+      },
+      {
+        description: 'Test zero values',
+        schedulerResourceInfo: {
+          memory: 0,
+          vcore: 0,
+          'ephemeral-storage': 0,
+          'hugepages-2Mi': 0,
+          'hugepages-1Gi': 0,
+          'pods': 0
+        },
+        expected: 'Memory: 0 bytes, CPU: 0, ephemeral-storage: n/a, hugepages-1Gi: n/a, hugepages-2Mi: n/a, pods: n/a'
+      },
+      {
+        description: 'Test resource ordering',
+        schedulerResourceInfo: {
+          'ephemeral-storage': 2048,
+          memory: 1024,
+          vcore: 2,
+          'TPU': 30000,
+          'GPU': 40000,
+          'hugepages-2Mi':2097152,
+          'hugepages-1Gi':1073741824,
+          'pods': 10000
+        },
+        expected: 'Memory: 1 KiB, CPU: 2m, ephemeral-storage: 2.05 KB, GPU: 40k, hugepages-1Gi: 1 GiB, hugepages-2Mi: 2 MiB, pods: 10k, TPU: 30k'
+      }
+    ];
+
+    testCases.forEach((testCase: TestCase) => {
+      const result = (service as any).formatResource(testCase.schedulerResourceInfo); // ignore type typecheck to access private method
+      expect(result).toEqual(testCase.expected);
+    });
   });
 });

--- a/src/app/services/scheduler/scheduler.service.spec.ts
+++ b/src/app/services/scheduler/scheduler.service.spec.ts
@@ -100,4 +100,49 @@ describe('SchedulerService', () => {
       expect(result).toEqual(testCase.expected);
     });
   });
+
+
+  it('should format SchedulerResourceInfo percentage correctly', () => {
+    type TestCase = {
+      description: string;
+      schedulerResourceInfo: SchedulerResourceInfo;
+      expected: string;
+    };
+  
+    const testCases: TestCase[] = [
+      {
+        description: 'test simple resourceInfo',
+        schedulerResourceInfo: {
+          'memory': 10,
+          'vcore': 50,
+        },
+        expected: 'Memory: 10%, CPU: 50%'
+      },
+      {
+        description: 'test undefined resourceInfo',
+        schedulerResourceInfo : undefined as any,
+        expected: `${NOT_AVAILABLE}`
+      },
+      {
+        description: 'test empty resourceInfo',
+        schedulerResourceInfo : {} as any,
+        expected: `${NOT_AVAILABLE}`
+      },
+      {
+        description: 'Test zero values and will only show memory and cpu',
+        schedulerResourceInfo: {
+          'memory': 0,
+          'vcore': 0,
+          'pods': 0,
+          'ephemeral-storage': 0,
+        },
+        expected: 'Memory: 0%, CPU: 0%'
+      }
+    ];
+
+    testCases.forEach((testCase: TestCase) => {
+      const result = (service as any).formatPercent(testCase.schedulerResourceInfo); // ignore type typecheck to access private method
+      expect(result).toEqual(testCase.expected);
+    });
+  });
 });

--- a/src/app/services/scheduler/scheduler.service.spec.ts
+++ b/src/app/services/scheduler/scheduler.service.spec.ts
@@ -77,7 +77,7 @@ describe('SchedulerService', () => {
           'hugepages-1Gi': 0,
           'pods': 0
         },
-        expected: 'Memory: 0 bytes, CPU: 0, ephemeral-storage: n/a, hugepages-1Gi: n/a, hugepages-2Mi: n/a, pods: n/a'
+        expected: 'Memory: 0 bytes, CPU: 0, pods: n/a, ephemeral-storage: n/a, hugepages-1Gi: n/a, hugepages-2Mi: n/a'
       },
       {
         description: 'Test resource ordering',
@@ -91,7 +91,7 @@ describe('SchedulerService', () => {
           'hugepages-1Gi':1073741824,
           'pods': 10000
         },
-        expected: 'Memory: 1 KiB, CPU: 2m, ephemeral-storage: 2.05 KB, GPU: 40k, hugepages-1Gi: 1 GiB, hugepages-2Mi: 2 MiB, pods: 10k, TPU: 30k'
+        expected: 'Memory: 1 KiB, CPU: 2m, pods: 10k, ephemeral-storage: 2.05 KB, GPU: 40k, hugepages-1Gi: 1 GiB, hugepages-2Mi: 2 MiB, TPU: 30k'
       }
     ];
 

--- a/src/app/services/scheduler/scheduler.service.spec.ts
+++ b/src/app/services/scheduler/scheduler.service.spec.ts
@@ -60,12 +60,12 @@ describe('SchedulerService', () => {
       {
         description: 'test undefined resourceInfo',
         schedulerResourceInfo : undefined as any,
-        expected: `Memory: ${NOT_AVAILABLE}, CPU: ${NOT_AVAILABLE}`
+        expected: `${NOT_AVAILABLE}`
       },
       {
         description: 'test empty resourceInfo',
         schedulerResourceInfo : {} as any,
-        expected: `Memory: ${NOT_AVAILABLE}, CPU: ${NOT_AVAILABLE}`
+        expected: `${NOT_AVAILABLE}`
       },
       {
         description: 'Test zero values',

--- a/src/app/services/scheduler/scheduler.service.spec.ts
+++ b/src/app/services/scheduler/scheduler.service.spec.ts
@@ -52,8 +52,8 @@ describe('SchedulerService', () => {
       {
         description: 'test simple resourceInfo',
         schedulerResourceInfo: {
-          memory: 1024,
-          vcore: 2,
+          'memory': 1024,
+          'vcore': 2,
         },
         expected: 'Memory: 1 KiB, CPU: 2m'
       },
@@ -70,8 +70,8 @@ describe('SchedulerService', () => {
       {
         description: 'Test zero values',
         schedulerResourceInfo: {
-          memory: 0,
-          vcore: 0,
+          'memory': 0,
+          'vcore': 0,
           'ephemeral-storage': 0,
           'hugepages-2Mi': 0,
           'hugepages-1Gi': 0,
@@ -83,8 +83,8 @@ describe('SchedulerService', () => {
         description: 'Test resource ordering',
         schedulerResourceInfo: {
           'ephemeral-storage': 2048,
-          memory: 1024,
-          vcore: 2,
+          'memory': 1024,
+          'vcore': 2,
           'TPU': 30000,
           'GPU': 40000,
           'hugepages-2Mi':2097152,

--- a/src/app/services/scheduler/scheduler.service.spec.ts
+++ b/src/app/services/scheduler/scheduler.service.spec.ts
@@ -77,7 +77,7 @@ describe('SchedulerService', () => {
           'hugepages-1Gi': 0,
           'pods': 0
         },
-        expected: 'Memory: 0 bytes, CPU: 0, pods: n/a, ephemeral-storage: n/a, hugepages-1Gi: n/a, hugepages-2Mi: n/a'
+        expected: 'Memory: 0 B, CPU: 0, pods: 0, ephemeral-storage: 0 B, hugepages-1Gi: 0 B, hugepages-2Mi: 0 B'
       },
       {
         description: 'Test resource ordering',
@@ -91,7 +91,7 @@ describe('SchedulerService', () => {
           'hugepages-1Gi':1073741824,
           'pods': 10000
         },
-        expected: 'Memory: 1 KiB, CPU: 2m, pods: 10k, ephemeral-storage: 2.05 KB, GPU: 40k, hugepages-1Gi: 1 GiB, hugepages-2Mi: 2 MiB, TPU: 30k'
+        expected: 'Memory: 1 KiB, CPU: 2m, pods: 10k, ephemeral-storage: 2.05 kB, GPU: 40k, hugepages-1Gi: 1 GiB, hugepages-2Mi: 2 MiB, TPU: 30k'
       }
     ];
 

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -328,7 +328,7 @@ export class SchedulerService {
     const formatted = [];
 
     if (resource && resource.memory !== undefined) {
-      formatted.push(`Memory: ${CommonUtil.formatBytes(resource.memory)}`);
+      formatted.push(`Memory: ${CommonUtil.formatMemoryBytes(resource.memory)}`);
     } else {
       formatted.push(`Memory: ${NOT_AVAILABLE}`);
     }
@@ -350,7 +350,7 @@ export class SchedulerService {
             if (resource[`ephemeral-storage`] == 0) {
               formatted.push(`ephemeral-storage: ${NOT_AVAILABLE}`);
             }else{
-              formatted.push(`ephemeral-storage: ${CommonUtil.formatBytes(resource[key])}`);
+              formatted.push(`ephemeral-storage: ${CommonUtil.formatEphemeralStorageBytes(resource[key])}`);
             }
             break;
           }

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -334,7 +334,7 @@ export class SchedulerService {
     }
 
     if (resource && resource.vcore !== undefined) {
-      formatted.push(`CPU: ${CommonUtil.formatCount(resource.vcore)}`);
+      formatted.push(`CPU: ${CommonUtil.formatCpuCore(resource.vcore)}`);
     } else {
       formatted.push(`CPU: ${NOT_AVAILABLE}`);
     }

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -331,7 +331,7 @@ export class SchedulerService {
       Object.keys(resource).sort(this.resourcesCompareFn).forEach((key) => {
         let value = resource[key];
         let formattedKey = key;
-        let formattedValue = NOT_AVAILABLE;
+        let formattedValue : string;
 
         switch(key){
           case "memory":
@@ -343,21 +343,16 @@ export class SchedulerService {
             formattedValue = CommonUtil.formatCpuCore(value);
             break;
           case "ephemeral-storage":
-            if (value !== 0){  // if value is 0, show NOT_AVAILABLE
-              formattedValue = CommonUtil.formatEphemeralStorageBytes(value);
-            }
+            formattedValue = CommonUtil.formatEphemeralStorageBytes(value);
             break;
           default:
-            if (value !== 0){ // if value is 0, show NOT_AVAILABLE
-              if (key.startsWith('hugepages-')) {
-                formattedValue = CommonUtil.formatMemoryBytes(value);
-              } else{
-                formattedValue = CommonUtil.formatOtherResource(value);
-              }
+            if (key.startsWith('hugepages-')) {
+              formattedValue = CommonUtil.formatMemoryBytes(value);
+            } else{
+              formattedValue = CommonUtil.formatOtherResource(value);
             }
             break;
          }
-        // }
         formatted.push(`${formattedKey}: ${formattedValue}`);
       });
     }

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -384,18 +384,17 @@ export class SchedulerService {
   private formatPercent(resource: SchedulerResourceInfo): string {
     const formatted = [];
 
-    if (resource && resource.memory !== undefined) {
-      formatted.push(`Memory: ${CommonUtil.formatPercent(resource.memory)}`);
-    } else {
-      formatted.push(`Memory: ${NOT_AVAILABLE}`);
+    if (resource) {
+      if (resource.memory !== undefined){
+        formatted.push(`Memory: ${CommonUtil.formatPercent(resource.memory)}`);
+      }
+      if (resource.vcore !== undefined){
+        formatted.push(`CPU: ${CommonUtil.formatPercent(resource.vcore)}`);
+      }
     }
-
-    if (resource && resource.vcore !== undefined) {
-      formatted.push(`CPU: ${CommonUtil.formatPercent(resource.vcore)}`);
-    } else {
-      formatted.push(`CPU: ${NOT_AVAILABLE}`);
+    if (formatted.length === 0) {
+      return NOT_AVAILABLE;
     }
-
     return formatted.join(', ');
   }
 

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -362,11 +362,9 @@ export class SchedulerService {
       });
     }
 
-    // Set CPU/Memory as NOT_AVAILABLE if it was not in Object.keys() or resource is undefined.
-    if (!resource || resource.vcore === undefined)
-      formatted.unshift(`CPU: ${NOT_AVAILABLE}`);
-    if (!resource || resource.memory === undefined)
-      formatted.unshift(`Memory: ${NOT_AVAILABLE}`);
+    if (formatted.length === 0) {
+      return NOT_AVAILABLE;
+    }
     return formatted.join(', ');
   } 
 

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -373,7 +373,8 @@ export class SchedulerService {
     const resourceOrder: { [key: string]: number } = {
       "memory": 1,
       "vcore": 2,
-      "ephemeral-storage": 3
+      "pods": 3,
+      "ephemeral-storage": 4
     };
     const orderA = a in resourceOrder ? resourceOrder[a] : Number.MAX_SAFE_INTEGER;
     const orderB = b in resourceOrder ? resourceOrder[b] : Number.MAX_SAFE_INTEGER;

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -362,7 +362,7 @@ export class SchedulerService {
       });
     }
 
-    // Set CPU/Memory as NOT_AVAILABLE if it was not in Object.keys(), for example: when guaranteed resource/queue limit were not set in queue 
+    // Set CPU/Memory as NOT_AVAILABLE if it was not in Object.keys() or resource is undefined.
     if (!resource || resource.vcore === undefined)
       formatted.unshift(`CPU: ${NOT_AVAILABLE}`);
     if (!resource || resource.memory === undefined)

--- a/src/app/utils/common.util.spec.ts
+++ b/src/app/utils/common.util.spec.ts
@@ -23,26 +23,39 @@ describe('CommonUtil', () => {
     expect(CommonUtil.createUniqId).toBeTruthy();
   });
 
-  it('should have formatBytes method', () => {
-    expect(CommonUtil.formatBytes).toBeTruthy();
+  it('checking formatMemoryBytes method result', () => {
+    const inputs: number[] = [0, 100, 1100, 1200000, 1048576000, 1300000000, 1400000000000, 1500000000000000, 1500000000000000000];
+    const expected: string[] = ['0 bytes', '100 bytes', '1.07 KiB', '1.14 MiB', '1,000 MiB', '1.21 GiB', '1.27 TiB', '1.33 PiB', '1.3 EiB'];
+    for (let index = 0; index < inputs.length; index = index + 1) {
+      expect(CommonUtil.formatMemoryBytes(inputs[index])).toEqual(expected[index]);
+      expect(CommonUtil.formatMemoryBytes(inputs[index].toString())).toEqual(expected[index]);
+    }
   });
 
-  it('checking formatBytes method result', () => {
-    const inputs: number[] = [0, 100, 1100, 1200000, 1048576000, 1300000000, 1400000000000, 1500000000000000];
-    const expected: string[] = ['0 bytes', '100 bytes', '1.07 Ki', '1.14 Mi', '1,000 Mi', '1.21 Gi', '1.27 Ti', '1.33 Pi'];
+  it('checking formatEphemeralStorageBytes method result', () => {
+    const inputs: number[] = [0, 100, 1100, 1200000, 1048576000, 1300000000, 1400000000000, 1500000000000000, 1500000000000000000];
+    const expected: string[] = ['0 bytes', '100 bytes', '1.1 KB', '1.2 MB', '1.05 GB', '1.3 GB', '1.4 TB', '1.5 PB', '1.5 EB'];
     for (let index = 0; index < inputs.length; index = index + 1) {
-      expect(CommonUtil.formatBytes(inputs[index])).toEqual(expected[index]);
-      expect(CommonUtil.formatBytes(inputs[index].toString())).toEqual(expected[index]);
+      expect(CommonUtil.formatEphemeralStorageBytes(inputs[index])).toEqual(expected[index]);
+      expect(CommonUtil.formatEphemeralStorageBytes(inputs[index].toString())).toEqual(expected[index]);
     }
   });
 
   it('checking formatCpuCore method result', () => {
-    const inputs: number[] = [0, 100, 1000, 5555, 10000, 10555, 10999, 10000000];
-    const expected: string[] = ['0','100m', '1', '5.56', '10', '10.56', '11', '10,000'];
+    const inputs: number[] = [0, 100, 1000, 1555, 1555555, 1555555555, 1555555555555, 1555555555555555, 1555555555555555555, 1555555555555555555555];
+    const expected: string[] = ['0','100m', '1', '1.56', '1.56k', '1.56M', '1.56G', '1.56T', '1.56P', '1.56E'];
     for (let index = 0; index < inputs.length; index = index + 1) {
       expect(CommonUtil.formatCpuCore(inputs[index])).toEqual(expected[index]);
       expect(CommonUtil.formatCpuCore(inputs[index].toString())).toEqual(expected[index]);
     }
   });
 
+  it('checking formatOtherResource method result', () => {
+    const inputs: number[] = [0, 100, 1000, 1555, 1555555, 1555555555, 1555555555555, 1555555555555555, 1555555555555555555];
+    const expected: string[] = ['0','100', '1k', '1.56k', '1.56M', '1.56G', '1.56T', '1.56P', '1.56E'];
+    for (let index = 0; index < inputs.length; index = index + 1) {
+      expect(CommonUtil.formatOtherResource(inputs[index])).toEqual(expected[index]);
+      expect(CommonUtil.formatOtherResource(inputs[index].toString())).toEqual(expected[index]);
+    }
+  });
 });

--- a/src/app/utils/common.util.spec.ts
+++ b/src/app/utils/common.util.spec.ts
@@ -25,7 +25,7 @@ describe('CommonUtil', () => {
 
   it('checking formatMemoryBytes method result', () => {
     const inputs: number[] = [0, 100, 1100, 1200000, 1048576000, 1300000000, 1400000000000, 1500000000000000, 1500000000000000000];
-    const expected: string[] = ['0 bytes', '100 bytes', '1.07 KiB', '1.14 MiB', '1,000 MiB', '1.21 GiB', '1.27 TiB', '1.33 PiB', '1.3 EiB'];
+    const expected: string[] = ['0 B', '100 B', '1.07 KiB', '1.14 MiB', '1,000 MiB', '1.21 GiB', '1.27 TiB', '1.33 PiB', '1.3 EiB'];
     for (let index = 0; index < inputs.length; index = index + 1) {
       expect(CommonUtil.formatMemoryBytes(inputs[index])).toEqual(expected[index]);
       expect(CommonUtil.formatMemoryBytes(inputs[index].toString())).toEqual(expected[index]);
@@ -34,7 +34,7 @@ describe('CommonUtil', () => {
 
   it('checking formatEphemeralStorageBytes method result', () => {
     const inputs: number[] = [0, 100, 1100, 1200000, 1048576000, 1300000000, 1400000000000, 1500000000000000, 1500000000000000000];
-    const expected: string[] = ['0 bytes', '100 bytes', '1.1 KB', '1.2 MB', '1.05 GB', '1.3 GB', '1.4 TB', '1.5 PB', '1.5 EB'];
+    const expected: string[] = ['0 B', '100 B', '1.1 kB', '1.2 MB', '1.05 GB', '1.3 GB', '1.4 TB', '1.5 PB', '1.5 EB'];
     for (let index = 0; index < inputs.length; index = index + 1) {
       expect(CommonUtil.formatEphemeralStorageBytes(inputs[index])).toEqual(expected[index]);
       expect(CommonUtil.formatEphemeralStorageBytes(inputs[index].toString())).toEqual(expected[index]);

--- a/src/app/utils/common.util.spec.ts
+++ b/src/app/utils/common.util.spec.ts
@@ -28,11 +28,21 @@ describe('CommonUtil', () => {
   });
 
   it('checking formatBytes method result', () => {
-    const inputs: number[] = [100, 1100, 1200000, 1300000000, 1400000000000, 1500000000000000];
-    const expected: string[] = ['100.0 bytes', '1.1 kB', '1.2 MB', '1.3 GB', '1.4 TB', '1.5 PB'];
+    const inputs: number[] = [0, 100, 1100, 1200000, 1048576000, 1300000000, 1400000000000, 1500000000000000];
+    const expected: string[] = ['0 bytes', '100 bytes', '1.07 Ki', '1.14 Mi', '1,000 Mi', '1.21 Gi', '1.27 Ti', '1.33 Pi'];
     for (let index = 0; index < inputs.length; index = index + 1) {
       expect(CommonUtil.formatBytes(inputs[index])).toEqual(expected[index]);
       expect(CommonUtil.formatBytes(inputs[index].toString())).toEqual(expected[index]);
     }
   });
+
+  it('checking formatCpuCore method result', () => {
+    const inputs: number[] = [0, 100, 1000, 5555, 10000, 10555, 10999, 10000000];
+    const expected: string[] = ['0','100m', '1', '5.56', '10', '10.56', '11', '10,000'];
+    for (let index = 0; index < inputs.length; index = index + 1) {
+      expect(CommonUtil.formatCpuCore(inputs[index])).toEqual(expected[index]);
+      expect(CommonUtil.formatCpuCore(inputs[index].toString())).toEqual(expected[index]);
+    }
+  });
+
 });

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -32,7 +32,7 @@ export class CommonUtil {
 
   static formatMemoryBytes(value: number | string): string {
     const units: readonly string[] = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
-    let unit: string = 'bytes';
+    let unit: string = 'B';
     let toValue = +value;
     for (let i = 0, unitslen = units.length; toValue / 1024 >= 1 && i < unitslen;i = i + 1) {
       toValue = toValue / 1024;
@@ -42,8 +42,8 @@ export class CommonUtil {
   }
 
   static formatEphemeralStorageBytes(value: number | string): string {
-    const units: readonly string[] = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
-    let unit: string = 'bytes';
+    const units: readonly string[] = ['kB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+    let unit: string = 'B';
     let toValue = +value;
     for (let i = 0, unitslen = units.length; toValue / 1000 >= 1 && i < unitslen;i = i + 1) {
       toValue = toValue / 1000;

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -30,12 +30,23 @@ export class CommonUtil {
     return uniqid;
   }
 
-  static formatBytes(value: number | string): string {
-    const units: readonly string[] = ['Ki', 'Mi', 'Gi', 'Ti', 'Pi'];
+  static formatMemoryBytes(value: number | string): string {
+    const units: readonly string[] = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
     let unit: string = 'bytes';
-    let toValue = +value
+    let toValue = +value;
     for (let i = 0, unitslen = units.length; toValue / 1024 >= 1 && i < unitslen;i = i + 1) {
       toValue = toValue / 1024;
+      unit = units[i];
+    }
+    return `${toValue.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${unit}`;
+  }
+
+  static formatEphemeralStorageBytes(value: number | string): string {
+    const units: readonly string[] = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+    let unit: string = 'bytes';
+    let toValue = +value;
+    for (let i = 0, unitslen = units.length; toValue / 1000 >= 1 && i < unitslen;i = i + 1) {
+      toValue = toValue / 1000;
       unit = units[i];
     }
     return `${toValue.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${unit}`;
@@ -46,22 +57,28 @@ export class CommonUtil {
   }
 
   static formatCpuCore(value: number | string): string {
-    const toValue = +value;
-
-    if (toValue == 0) {
-      return `${toValue}`;
+    const units: readonly string[] = ['m', '', 'k', 'M', 'G', 'T', 'P', 'E'];
+    let unit: string = '';
+    let toValue = +value;
+    if (toValue > 0) {
+      unit = units[0];
     }
-
-    if (toValue >= 1000) {
-      return `${(toValue / 1000).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+    for (let i = 1, unitslen = units.length; toValue / 1000 >= 1 && i < unitslen;i = i + 1) {
+      toValue = toValue / 1000;
+      unit = units[i];
     }
-
-    return `${toValue}m`;
+    return `${toValue.toLocaleString(undefined, { maximumFractionDigits: 2 })}${unit}`;
   }
 
   static formatOtherResource(value: number | string): string {
-    const toValue = +value;
-    return toValue.toLocaleString();
+    const units: readonly string[] = ['k', 'M', 'G', 'T', 'P', 'E'];
+    let unit: string = '';
+    let toValue = +value;
+    for (let i = 0, unitslen = units.length; toValue / 1000 >= 1 && i < unitslen;i = i + 1) {
+      toValue = toValue / 1000;
+      unit = units[i];
+    }
+    return `${toValue.toLocaleString(undefined, { maximumFractionDigits: 2 })}${unit}`;
   }
 
   static resourceColumnFormatter(value: string): string {

--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -31,28 +31,32 @@ export class CommonUtil {
   }
 
   static formatBytes(value: number | string): string {
-    const units: readonly string[] = ['kB', 'MB', 'GB', 'TB', 'PB'];
+    const units: readonly string[] = ['Ki', 'Mi', 'Gi', 'Ti', 'Pi'];
     let unit: string = 'bytes';
     let toValue = +value
-    for (let i = 0, unitslen = units.length; toValue / 1000 >= 1 && i < unitslen;i = i + 1) {
-      toValue = toValue / 1000;
+    for (let i = 0, unitslen = units.length; toValue / 1024 >= 1 && i < unitslen;i = i + 1) {
+      toValue = toValue / 1024;
       unit = units[i];
     }
-    return `${toValue.toFixed(1)} ${unit}`;
+    return `${toValue.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${unit}`;
   }
 
   static isEmpty(arg: object | any[]): boolean {
     return Object.keys(arg).length === 0;
   }
 
-  static formatCount(value: number | string): string {
-    const unit = 'K';
+  static formatCpuCore(value: number | string): string {
     const toValue = +value;
-    if (toValue >= 10000) {
-      return `${(toValue / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 })} ${unit}`;
+
+    if (toValue == 0) {
+      return `${toValue}`;
     }
 
-    return toValue.toLocaleString();
+    if (toValue >= 1000) {
+      return `${(toValue / 1000).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+    }
+
+    return `${toValue}m`;
   }
 
   static formatOtherResource(value: number | string): string {


### PR DESCRIPTION
### What is this PR for?

Change below resources presentation in YuniKorn UI:

1. Chang 'kB', 'MB', 'GB', 'TB', 'PB’→’Ki’, ‘Mi’, ‘Gi’, ‘Ti’, ‘Pi’
2. Align CPU unit with K8S, remove ‘k’ from CPU unit and use ‘m’ to present millicpu. For example: 100 → 100m, 1000 -> 1, 10k → 10
3. Change the fixed digit number from 1 to 2

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2140

### How should this be tested?
`make test` should pass.
Run `yarn start` to check new resource presentation.


### Screenshots (if appropriate)
![YUNIKORN-2140 before vs after drawio](https://github.com/apache/yunikorn-web/assets/26764036/9ac75fbe-8343-452b-96ff-3c752b669a05)


### Questions:
NA