### PR TITLE
[YUNIKORN-2150] Node resource utilization chart does not render properly

### DIFF
--- a/json-db.json
+++ b/json-db.json
@@ -751,422 +751,63 @@
       "reservations": []
     }
   ],
-  "utilization": [
-    {
-      "type": "ephemeral-storage",
-      "utilization": [
-        {
-          "bucketName": "0-10%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "10-20%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "20-30%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "30-40%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "40-50%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "50-60%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "60-70%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "70-80%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "80-90%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "90-100%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "hugepages-1Gi",
-      "utilization": [
-        {
-          "bucketName": "0-10%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "10-20%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "20-30%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "30-40%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "40-50%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "50-60%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "60-70%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "70-80%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "80-90%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "90-100%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "hugepages-2Mi",
-      "utilization": [
-        {
-          "bucketName": "0-10%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "10-20%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "20-30%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "30-40%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "40-50%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "50-60%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "60-70%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "70-80%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "80-90%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "90-100%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "memory",
-      "utilization": [
-        {
-          "bucketName": "0-10%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "10-20%",
-          "numOfNodes": 1,
-          "nodeNames": [
-            "aethergpu"
-          ]
-        },
-        {
-          "bucketName": "20-30%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "30-40%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "40-50%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "50-60%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "60-70%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "70-80%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "80-90%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "90-100%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        }
-      ]
-    },
-    {
-      "type": "pods",
-      "utilization": [
-        {
-          "bucketName": "0-10%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "10-20%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "20-30%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "30-40%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "40-50%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "50-60%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "60-70%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "70-80%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "80-90%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        },
-        {
-          "bucketName": "90-100%",
-          "numOfNodes": -1,
-          "nodeNames": [
-            "N/A"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "vcore",
-      "utilization": [
-        {
-          "bucketName": "0-10%",
-          "numOfNodes": 1,
-          "nodeNames": [
-            "aethergpu"
-          ]
-        },
-        {
-          "bucketName": "10-20%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "20-30%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "30-40%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "40-50%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "50-60%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "60-70%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "70-80%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "80-90%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        },
-        {
-          "bucketName": "90-100%",
-          "numOfNodes": 0,
-          "nodeNames": null
-        }
-      ]
-    }
-  ],
+  "node-utilization": {
+    "type": "vcore",
+    "utilization": [
+      {
+        "bucketName": "0-10%",
+        "numOfNodes": 1,
+        "nodeNames": [
+          "aethergpu"
+        ]
+      },
+      {
+        "bucketName": "10-20%",
+        "numOfNodes": 3,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "20-30%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "30-40%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "40-50%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "50-60%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "60-70%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "70-80%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "80-90%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      },
+      {
+        "bucketName": "90-100%",
+        "numOfNodes": 0,
+        "nodeNames": null
+      }
+    ]
+  },
   "partitions": [
     {
       "clusterId": "mycluster",

--- a/json-routes.json
+++ b/json-routes.json
@@ -1,5 +1,5 @@
 {
-  "/ws/v1/scheduler/node-utilization": "/utilization",
+  "/ws/v1/scheduler/node-utilization": "/node-utilization",
   "/ws/v1/*": "/$1",
   "/history/apps": "/appHistory",
   "/history/containers": "/containerHistory",

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -112,15 +112,13 @@ export class DashboardComponent implements OnInit {
 
     this.scheduler.fetchNodeUtilization().subscribe((data) => {
       const utilizationData: Record<string, number> = {};
-      data.forEach((utilizationInfo) => {
-        utilizationInfo.utilization.forEach(({ bucketName, numOfNodes }) => {
-          const numOfNodesValue = numOfNodes === -1 ? 0 : numOfNodes;
-          if (utilizationData[bucketName]) {
-            utilizationData[bucketName] += numOfNodesValue;
-          } else {
-            utilizationData[bucketName] = numOfNodesValue;
-          }
-        });
+      data.utilization.forEach(({ bucketName, numOfNodes }) => {
+        const numOfNodesValue = numOfNodes === -1 ? 0 : numOfNodes;
+        if (utilizationData[bucketName]) {
+          utilizationData[bucketName] += numOfNodesValue;
+        } else {
+          utilizationData[bucketName] = numOfNodesValue;
+        }
       });
 
       this.nodeUtilizationData = [];

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -254,9 +254,9 @@ export class SchedulerService {
     );
   }
 
-  fetchNodeUtilization(): Observable<NodeUtilization[]>{
+  fetchNodeUtilization(): Observable<NodeUtilization>{
     const nodeUtilizationUrl = `${this.envConfig.getSchedulerWebAddress()}/ws/v1/scheduler/node-utilization`;
-    return this.httpClient.get(nodeUtilizationUrl).pipe(map((data: any) => data as NodeUtilization[]));
+    return this.httpClient.get(nodeUtilizationUrl).pipe(map((data: any) => data as NodeUtilization));
   }
 
   fecthHealthchecks(): Observable<SchedulerHealthInfo> {


### PR DESCRIPTION
### What is this PR for?
Fix the node resource utilization chart so it can correctly render with dominant resource.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2150

### How should this be tested?
make test should pass. )
Run `kubectl port-forward svc/yunikorn-service 9889 9080 -n yunikorn` to forward yunikron rest endpoint.
(Do remember to update the core version.)
Open another teminal and run` yarn start ` and check the result of http://localhost:4200/#/dashboard


### Screenshots (if appropriate)
<img width="1470" alt="After YUNIORN-2150" src="https://github.com/apache/yunikorn-web/assets/26764036/ce38d085-32ae-4134-a384-bdd825ca50dd">

### Questions:
NA
