### PR TITLE
[YUNIKORN-2191] Remove partition column in Nodes page

### DIFF
--- a/src/app/components/nodes-view/nodes-view.component.ts
+++ b/src/app/components/nodes-view/nodes-view.component.ts
@@ -66,7 +66,6 @@ export class NodesViewComponent implements OnInit {
       { colId: 'nodeId', colName: 'Node ID' },
       { colId: 'rackName', colName: 'Rack Name' },
       { colId: 'hostName', colName: 'Host Name' },
-      { colId: 'partitionName', colName: 'Partition' },
       { colId: 'capacity', colName: 'Capacity', colFormatter: CommonUtil.resourceColumnFormatter },
       { colId: 'occupied', colName: 'Used', colFormatter: CommonUtil.resourceColumnFormatter },
       {

--- a/src/app/components/nodes-view/nodes-view.component.ts
+++ b/src/app/components/nodes-view/nodes-view.component.ts
@@ -136,7 +136,6 @@ export class NodesViewComponent implements OnInit {
       )
       .subscribe((data) => {
         this.nodeDataSource.data = data;
-        console.log(data);
       });
   }
 


### PR DESCRIPTION
### What is this PR for?
In the Nodes page, it displays all nodes under a specific partition. Since the partition is selected beforehand, the partition column in the table is redundant. So this PR removes it.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
[YUNIKORN-2191](https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2191)

### How should this be tested?
local build

### Screenshots (if appropriate)
|before|after|
|---|---|
|![](https://issues.apache.org/jira/secure/attachment/13064685/origin.png)|![](https://issues.apache.org/jira/secure/attachment/13064684/after_remove_partition_col.png)|

### Questions:
N/A