### PR TITLE
[YUNIKORN-2249] Add Accept-Encoding header when fetch queue application API

### DIFF
--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {AllocationInfo} from '@app/models/alloc-info.model';
 import {AppInfo} from '@app/models/app-info.model';
@@ -82,8 +82,10 @@ export class SchedulerService {
 
   fetchAppList(partitionName: string, queueName: string): Observable<AppInfo[]> {
     const appsUrl = `${this.envConfig.getSchedulerWebAddress()}/ws/v1/partition/${partitionName}/queue/${queueName}/applications`;
+    const headers = new HttpHeaders();
+    headers.set('Accept-Encoding', 'gzip')
 
-    return this.httpClient.get(appsUrl).pipe(
+    return this.httpClient.get(appsUrl, {headers}).pipe(
       map((data: any) => {
         const result: AppInfo[] = [];
 


### PR DESCRIPTION
### What is this PR for?
When the API response size is large, it takes a long time to transfer data. 
This PR adds a 'Accept-Encoding' request header. If the client (web side) indicates gzip encoding, the scheduler will compress the data before sending it back. So it can reduce the data size and transfer time.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
[YUNIKORN-2249](https://issues.apache.org/jira/browse/YUNIKORN-2249)

### How should this be tested?
local build

### Screenshots (if appropriate)
N/A

### Questions:
N/A