### PR TITLE
[YUNIKORN-2340] Upgrade actions versions in Github Action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: .go_version
       - name: Check License
         run: make license-check
       - name: Set Node.js Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - run: |


### PR DESCRIPTION
### What is this PR for?
Bump below actions verions to surpress the "Node.js 16 actions are deprecated." warning message:

1. actions/checkout (v3 -> v4)
2. actions/setup-node (v3 -> v4)
3. actions/setup-go (v3 -> v5)   ([Only support node js 20 in v5](https://github.com/actions/setup-go/releases))

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Update below repo's actions version:
1. yunikorn-k8shim
2. yunikorn-core
3. yunikorn-scheduler-interface

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2340

### How should this be tested?
Tested in Github action.  Create a pull request to master branch and check the Actions result.
ex: https://github.com/chenyulin0719/yunikorn-web/actions/runs/7694231502

### Screenshots (if appropriate)
After:
<img width="1452" alt="image" src="https://github.com/apache/yunikorn-web/assets/26764036/cd5c01d9-f352-4474-b2e9-281f9071f3e0">

Before:
<img width="1444" alt="image" src="https://github.com/apache/yunikorn-web/assets/26764036/68f8550b-7759-40d4-8422-610deb34edc6">


### Questions:
NA
