### PR TITLE
[YUNIKORN-2379] Adjust layout of node utilization chart(Web)

### DIFF
--- a/src/app/components/nodes-view/nodes-view.component.html
+++ b/src/app/components/nodes-view/nodes-view.component.html
@@ -197,9 +197,8 @@
       ></mat-paginator>
     </div>
   </div>
-  <div class="flex-grid">
-    <div class="flex-primary">
-      <app-node-utilizations [partitionSelected]="partitionSelected" />
-    </div>
-  </div>
+</div>
+
+<div class="node-utilizations-view">
+  <app-node-utilizations [partitionSelected]="partitionSelected" />
 </div>

--- a/src/app/components/nodes-view/nodes-view.component.scss
+++ b/src/app/components/nodes-view/nodes-view.component.scss
@@ -127,7 +127,7 @@
     margin-left: 10px;
   }
   .node-allocations {
-    margin-top: 40px;
+    margin-top: 20px;
     .mat-mdc-table {
       margin-top: 20px;
     }
@@ -139,4 +139,8 @@
     width: 100%;
     text-align: center;
   }
+}
+
+.node-utilizations-view {
+  margin-top: 20px
 }


### PR DESCRIPTION
### What is this PR for?

1. Move the Node Resource Utilization chart to top level of node view and add margin-top for it.
2. Algin the margin-top to 20px in node view


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2379

### How should this be tested?
- yarn start:srv
- yarn start 

### Screenshots (if appropriate)
<img width="562" alt="image" src="https://github.com/apache/yunikorn-web/assets/26764036/338391ba-24ee-4a63-83bf-fc98a03abc9f">


### Questions:
NA
