### PR TITLE
[YUNIKORN-2390] Improve mousehover result for node utilization chart(Web)

### DIFF
--- a/src/app/components/vertical-bar-chart/vertical-bar-chart.component.ts
+++ b/src/app/components/vertical-bar-chart/vertical-bar-chart.component.ts
@@ -106,7 +106,7 @@ export class VerticalBarChartComponent implements OnInit, AfterViewInit, OnChang
             onClick: (e) => { }, // disable legend click event
             onHover: (event, legendItem, legend) => {
               let datasetIndex = legendItem.datasetIndex
-              //Update the other datasets background color
+              // Update the other datasets background color
               if (this.barChart != undefined) {
                 this.barChart.data.datasets.forEach((dataset, i) => {
                   if (i != datasetIndex && this.barChart != undefined) {
@@ -169,7 +169,7 @@ export class VerticalBarChartComponent implements OnInit, AfterViewInit, OnChang
                     }
                   });
                 });
-                //Update the other datasets background color
+                // Update the other datasets background color
                 const datasetIndex = chartElement[0].datasetIndex;
                 this.barChart?.data.datasets?.forEach((dataset, i) => {
                   if (i != datasetIndex && this.barChart != undefined) {

--- a/src/app/components/vertical-bar-chart/vertical-bar-chart.component.ts
+++ b/src/app/components/vertical-bar-chart/vertical-bar-chart.component.ts
@@ -106,17 +106,26 @@ export class VerticalBarChartComponent implements OnInit, AfterViewInit, OnChang
             onClick: (e) => { }, // disable legend click event
             onHover: (event, legendItem, legend) => {
               let datasetIndex = legendItem.datasetIndex
-              if (this.barChart != undefined && datasetIndex !== undefined) {
-                this.barChart.data.datasets[datasetIndex].backgroundColor = this.adjustOpacity(this.barChartDataSets[datasetIndex].backgroundColor, 0.5);
+              //Update the other datasets background color
+              if (this.barChart != undefined) {
+                this.barChart.data.datasets.forEach((dataset, i) => {
+                  if (i != datasetIndex && this.barChart != undefined) {
+                    this.barChart.data.datasets[i].backgroundColor = this.adjustOpacity(this.barChartDataSets[i].backgroundColor, 0.2);
+                  }
+                })
               }
-              this.barChart?.update("resize");
+              this.barChart?.update("active");
             },
             onLeave: (event, legendItem, legend) => {
-              let datasetIndex = legendItem.datasetIndex
-              if (this.barChart != undefined && datasetIndex !== undefined) {
-                this.barChart.data.datasets[datasetIndex].backgroundColor = this.barChartDataSets[datasetIndex].backgroundColor;
+              // Reset datasets background color
+              if (this.barChart != undefined) {
+                this.barChart.data.datasets.forEach((dataset, i) => {
+                  if (this.barChart != undefined) {
+                    this.barChart.data.datasets[i].backgroundColor = this.barChartDataSets[i].backgroundColor;
+                  }
+                })
               }
-              this.barChart?.update("resize");
+              this.barChart?.update("active");
             },
           },
           title: {
@@ -128,12 +137,6 @@ export class VerticalBarChartComponent implements OnInit, AfterViewInit, OnChang
             callbacks: {
               label: function (context) {
                 return barChartDataSets[context.datasetIndex].label;
-              },
-              labelColor: function (context) {
-                return {
-                  borderColor: barChartDataSets[context.datasetIndex].backgroundColor,
-                  backgroundColor: barChartDataSets[context.datasetIndex].backgroundColor,
-                };
               },
               footer: function (context) {
                 // show bar description on tooltip footer
@@ -166,11 +169,13 @@ export class VerticalBarChartComponent implements OnInit, AfterViewInit, OnChang
                     }
                   });
                 });
-                //Update the target dataset's background color
+                //Update the other datasets background color
                 const datasetIndex = chartElement[0].datasetIndex;
-                if (this.barChart != undefined) {
-                  this.barChart.data.datasets[datasetIndex].backgroundColor = this.adjustOpacity(this.barChartDataSets[datasetIndex].backgroundColor, 0.5);
-                }
+                this.barChart?.data.datasets?.forEach((dataset, i) => {
+                  if (i != datasetIndex && this.barChart != undefined) {
+                    this.barChart.data.datasets[i].backgroundColor = this.adjustOpacity(this.barChartDataSets[i].backgroundColor, 0.2);
+                  }
+                })
               } else {
                 // Reset datasets background color
                 this.barChart?.data.datasets?.forEach((dataset, i) => {
@@ -181,7 +186,7 @@ export class VerticalBarChartComponent implements OnInit, AfterViewInit, OnChang
                   });
                 });
               }
-              this.barChart?.update("resize");
+              this.barChart?.update("active");
             }
           }
         },


### PR DESCRIPTION
### What is this PR for?
When hovering a bar of node utilization chart, change the opacity of the other resource bars to 0.2
 
### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2390

### How should this be tested?
- make lint
- make license-check
- yarn test:coverage
- yarn start:srv
- yarn start (check the node utilization chart)

### Screenshots (if appropriate)
![demo for new hovering behavior](https://github.com/apache/yunikorn-web/assets/26764036/9605006b-cded-45db-9358-8c8f77da105b)


### Questions:
NA
