### PR TITLE
[YUNIKORN-2422] Web: create reproducible binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /out-tsc
 /bazel-out
 /tools
+/build.date
 
 # Node
 /node_modules


### PR DESCRIPTION
### What is this PR for?
Ensure that yunikorn-web binary uses consistent build ID and build date so that builds are reproducible.

The git commit timestamp is used (if possible) for the build date, and cached in the `build.date` file so that it can be included in release tarballs. The go-generated build ID is set to an empty string.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2422

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
