### PR TITLE
[YUNIKORN-2679] Add copy URL button on the allocations panel

### DIFF
--- a/src/app/components/apps-view/apps-view.component.html
+++ b/src/app/components/apps-view/apps-view.component.html
@@ -145,6 +145,7 @@
       <mat-drawer-content>
         <div class="header">
           <span>{{ selectedRow?.applicationId }} ({{ selectedRow?.allocations?.length }} allocations)</span>
+          <span class="far fa-clipboard copy-btn" (click)="copyLinkToClipboard()" matTooltip="Click to copy the URL to this view" matTooltipShowDelay="500"></span>
           <span class="far fa-solid fa-xmark close-btn" (click)="closeDrawer()"></span>
         </div>
         <div class="content">
@@ -162,7 +163,8 @@
               </ng-container>
 
               <ng-container *ngIf="columnDef.colId === 'resource'; else renderNext_3">
-                <mat-cell *matCellDef="let element" class="allocations-data" [style.flex]="columnDef?.colWidth || 1" >
+                <mat-cell *matCellDef="let element" class="allocations-data" [style.flex]="columnDef?.colWidth || 1" matTooltip="
+                          {{element[columnDef.colId]}}" matTooltipShowDelay="500" >
                   <ng-container *ngIf="columnDef.colFormatter; else showAllocRowData;">
                     <ng-container *ngIf="columnDef.colFormatter(element[columnDef.colId]) as colValue">
                       <ul class="mat-res-ul">
@@ -188,7 +190,7 @@
                           [class]="allocationsToggle ? '' : 'ellipsis'"
                           [style.flex]="columnDef?.colWidth || 1"
                           [style.min-height]="allocationsToggle ? '96px' : 'unset'"
-                          [title]="element[columnDef.colId]"
+                          matTooltip="{{element[columnDef.colId]}}" matTooltipShowDelay="500"
                 >{{ element[columnDef.colId] || 'n/a' }}</mat-cell>
               </ng-template>
             </ng-container>

--- a/src/app/components/apps-view/apps-view.component.scss
+++ b/src/app/components/apps-view/apps-view.component.scss
@@ -189,6 +189,11 @@
       color: #f44336;
     }
   }
+  .copy-btn {
+    font-size: 1em;
+    cursor: pointer;
+    padding-left: 5px;
+  }
   .header {
     margin: 20px;
     font-weight: 100;

--- a/src/app/components/apps-view/apps-view.component.spec.ts
+++ b/src/app/components/apps-view/apps-view.component.spec.ts
@@ -16,26 +16,27 @@
  * limitations under the License.
  */
 
-import {DebugElement} from '@angular/core';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {FormsModule} from '@angular/forms';
-import {MatDividerModule} from '@angular/material/divider';
-import {MatInputModule} from '@angular/material/input';
-import {MatPaginatorModule} from '@angular/material/paginator';
-import {MatSelectModule} from '@angular/material/select';
-import {MatSortModule} from '@angular/material/sort';
-import {MatTableModule} from '@angular/material/table';
-import {MatTooltipModule} from '@angular/material/tooltip';
-import {By, HAMMER_LOADER} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {RouterTestingModule} from '@angular/router/testing';
-import {AppInfo} from '@app/models/app-info.model';
-import {SchedulerService} from '@app/services/scheduler/scheduler.service';
-import {MockNgxSpinnerService, MockSchedulerService} from '@app/testing/mocks';
-import {NgxSpinnerService} from 'ngx-spinner';
-import {of} from 'rxjs';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { By, HAMMER_LOADER } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AppInfo } from '@app/models/app-info.model';
+import { SchedulerService } from '@app/services/scheduler/scheduler.service';
+import { MockNgxSpinnerService, MockSchedulerService } from '@app/testing/mocks';
+import { NgxSpinnerService } from 'ngx-spinner';
+import { of } from 'rxjs';
 
-import {AppsViewComponent} from './apps-view.component';
+import { AppsViewComponent } from './apps-view.component';
 
 describe('AppsViewComponent', () => {
   let component: AppsViewComponent;
@@ -55,6 +56,7 @@ describe('AppsViewComponent', () => {
         MatInputModule,
         MatTooltipModule,
         MatSelectModule,
+        MatSidenavModule,
       ],
       providers: [
         { provide: SchedulerService, useValue: MockSchedulerService },
@@ -75,23 +77,35 @@ describe('AppsViewComponent', () => {
     let service: SchedulerService;
     service = TestBed.inject(SchedulerService);
     let appInfo = new AppInfo(
-        'app1',
-        "Memory: 500.0 KB, CPU: 10, pods: 1",
-        "Memory: 0.0 bytes, CPU: 0, pods: n/a",
-        '',
-        1,
-        2,
-        [],
-        2,
-        'RUNNING',
-        []
+      'app1',
+      'Memory: 500.0 KB, CPU: 10, pods: 1',
+      'Memory: 0.0 bytes, CPU: 0, pods: n/a',
+      '',
+      1,
+      2,
+      [],
+      2,
+      'RUNNING',
+      []
     );
     spyOn(service, 'fetchAppList').and.returnValue(of([appInfo]));
-    component.fetchAppListForPartitionAndQueue("default", "root");
+    component.fetchAppListForPartitionAndQueue('default', 'root');
     component.toggle();
     fixture.detectChanges();
     const debugEl: DebugElement = fixture.debugElement;
-    expect(debugEl.query(By.css('mat-cell.mat-column-usedResource')).nativeElement.innerText).toContain('Memory: 500.0 KB\nCPU: 10\npods: 1');
-    expect(debugEl.query(By.css('mat-cell.mat-column-pendingResource')).nativeElement.innerText).toContain('Memory: 0.0 bytes\nCPU: 0\npods: n/a');
+    expect(
+      debugEl.query(By.css('mat-cell.mat-column-usedResource')).nativeElement.innerText
+    ).toContain('Memory: 500.0 KB\nCPU: 10\npods: 1');
+    expect(
+      debugEl.query(By.css('mat-cell.mat-column-pendingResource')).nativeElement.innerText
+    ).toContain('Memory: 0.0 bytes\nCPU: 0\npods: n/a');
+  });
+
+  it('should copy the allocations URL to clipboard', () => {
+    const debugEl: DebugElement = fixture.debugElement;
+    const copyButton = debugEl.query(By.css('.copy-btn'));
+    const copyButtonSpy = spyOn(component, 'copyLinkToClipboard').and.callThrough();
+    copyButton.triggerEventHandler('click', null);
+    expect(copyButtonSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/components/apps-view/apps-view.component.spec.ts
+++ b/src/app/components/apps-view/apps-view.component.spec.ts
@@ -104,7 +104,7 @@ describe('AppsViewComponent', () => {
   it('should copy the allocations URL to clipboard', () => {
     const debugEl: DebugElement = fixture.debugElement;
     const copyButton = debugEl.query(By.css('.copy-btn'));
-    const copyButtonSpy = spyOn(component, 'copyLinkToClipboard').and.callThrough();
+    const copyButtonSpy = spyOn(component, 'copyLinkToClipboard');
     copyButton.triggerEventHandler('click', null);
     expect(copyButtonSpy).toHaveBeenCalled();
   });

--- a/src/app/components/apps-view/apps-view.component.ts
+++ b/src/app/components/apps-view/apps-view.component.ts
@@ -407,11 +407,9 @@ export class AppsViewComponent implements OnInit {
 
   copyLinkToClipboard() {
     const url = window.location.href.split('?')[0];
-    const el = document.createElement('textarea');
-    el.value = `${url}?partition=${this.partitionSelected}&queue=${this.leafQueueSelected}&applicationId=${this?.selectedRow?.applicationId}`;
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand('copy');
-    document.body.removeChild(el);
+    const copyString = `${url}?partition=${this.partitionSelected}&queue=${this.leafQueueSelected}&applicationId=${this?.selectedRow?.applicationId}`;
+    navigator.clipboard
+      .writeText(copyString)
+      .catch((error) => console.error('Writing to the clipboard is not allowed. ', error));
   }
 }

--- a/src/app/components/apps-view/apps-view.component.ts
+++ b/src/app/components/apps-view/apps-view.component.ts
@@ -404,4 +404,14 @@ export class AppsViewComponent implements OnInit {
     this.matDrawer.close();
     this.removeRowSelection();
   }
+
+  copyLinkToClipboard() {
+    const url = window.location.href.split('?')[0];
+    const el = document.createElement('textarea');
+    el.value = `${url}?partition=${this.partitionSelected}&queue=${this.leafQueueSelected}&applicationId=${this?.selectedRow?.applicationId}`;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+  }
 }

--- a/src/app/components/licenses-modal/licenses-modal.component.spec.ts
+++ b/src/app/components/licenses-modal/licenses-modal.component.spec.ts
@@ -19,7 +19,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LicensesModalComponent } from './licenses-modal.component';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('LicensesModalComponent', () => {
@@ -30,7 +30,7 @@ describe('LicensesModalComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [LicensesModalComponent],
       providers: [{ provide: MatDialogRef, useValue: {} }],
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, MatDialogModule],
     }).compileComponents();
     fixture = TestBed.createComponent(LicensesModalComponent);
     component = fixture.componentInstance;


### PR DESCRIPTION
### What is this PR for?
This PR adds a copy button to the allocations panel. It is using the hotlinking feature that was implemented with [YUNIKORN-2624](https://issues.apache.org/jira/browse/YUNIKORN-2624)

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-2679 Add copy URL button on the allocations panel](https://issues.apache.org/jira/browse/YUNIKORN-2679)

### How should this be tested?
Open the allocations tab, in the title bar there should be a clipboard icon. Clicking that icon it should copy the URL to that view. 

### Screenshots (if appropriate)
<img width="739" alt="image" src="https://github.com/apache/yunikorn-web/assets/5342224/02ce5464-f2c2-419a-b968-d0d26d071f49">

### Note
The test is added for the feature, and alongside that I have added a minor fix to the `licenses-modal` test file that was outputting some errors due to a missing import.
