### PR TITLE
[YUNIKORN-2729] remove `--new-from-rev` from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ lint: $(GOLANGCI_LINT_BIN)
 	@git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
 	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \
-	"$(GOLANGCI_LINT_BIN)" run --new-from-rev=$${headSHA}
+	"$(GOLANGCI_LINT_BIN)" run
 
 .PHONY: license-check
 # This is a bit convoluted but using a recursive grep on linux fails to write anything when run


### PR DESCRIPTION
### What is this PR for?
- remove `--new-from-rev` from Makefile
- for lint 

### What type of PR is it?

*  Improvement

### Todos
N/A

### What is the Jira issue?
- [remove `--new-from-rev` from Makefile](https://issues.apache.org/jira/browse/YUNIKORN-2729)

### How should this be tested?

`make lint`

### Screenshots (if appropriate)

### Questions:
N/A
