### PR TITLE
[YUNIKORN-2799] Solve dockerfile warning which emerged while building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG NODE_VERSION
+ARG NODE_VERSION=20
 # Buildstage: use the local architecture
-FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine as buildstage
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine AS buildstage
 
 WORKDIR /work
 # Only copy what is needed for the build
@@ -29,10 +29,10 @@ RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 pnpm i
 RUN pnpm build:prod
 
 # Imagestage: use scratch base image
-FROM --platform=$TARGETPLATFORM scratch
+FROM scratch
 COPY --chown=0:0 NOTICE LICENSE build/prod/yunikorn-web /
 COPY --chown=0:0 --from=buildstage /work/dist/yunikorn-web /html/
 EXPOSE 9889
-ENV DOCUMENT_ROOT /html
+ENV DOCUMENT_ROOT=/html
 USER 4444:4444
 ENTRYPOINT [ "/yunikorn-web" ]


### PR DESCRIPTION
### What is this PR for?
 1 warning found:
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 17)
Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior
More info: https://docs.docker.com/go/dockerfile/rule/redundant-target-platform/
Dockerfile:17
```
  15 |     # See the License for the specific language governing permissions and
  16 |     # limitations under the License.
  17 | >>> FROM --platform=$TARGETPLATFORM scratch
  18 |     COPY --chown=0:0 LICENSE NOTICE third-party-licenses.md yunikorn-scheduler /
  19 |     USER 4444:4444
```

from docker version 27.1.1

suggested change: remove `--platform=$TARGETPLATFORM` in dockerfile
ref: https://docs.docker.com/reference/build-checks/redundant-target-platform/#examples

change: 
1. shim: RedundantTargetPlatform
2. web: 
 - RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior (line 32)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 36)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 20)
 - InvalidDefaultArgInFrom: Default value for ARG node:${NODE_VERSION}-alpine results in empty or invalid base image name (line 20)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2799

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
