### PR TITLE
[YUNIKORN-2913] Fix contrast issue in Applications view

### DIFF
--- a/src/app/components/apps-view/apps-view.component.scss
+++ b/src/app/components/apps-view/apps-view.component.scss
@@ -119,6 +119,10 @@
     --mdc-chip-label-text-weight: 400;
   }
 
+  .selected-row .mat-mdc-standard-chip {
+    --mdc-chip-label-text-color: #fff;
+  }
+
   .mat-mdc-header-cell {
     font-size: 15px;
     font-weight: bold;


### PR DESCRIPTION
### What is this PR for?
This PR resolves the issue in the applications view. When an application is selected in the table, there is a low contrast issue where resources are not visible. 

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2913](https://issues.apache.org/jira/browse/YUNIKORN-2913)

### How should this be tested?
It might be hard to notice, but on strange windows sizing that will allow you to notice resources behind the sidebar. The other way is to disable the sidebar (or misconfigure the module federation plugin - set remote entry and component to some random strings in env)

### Screenshots (if appropriate)

Before:
<img width="2032" alt="Screenshot 2024-10-10 at 13 15 19" src="https://github.com/user-attachments/assets/a517c92e-8bba-4c6d-aa1a-464cd44ae01d">

Fixed:
<img width="2032" alt="Screenshot 2024-10-10 at 13 16 09" src="https://github.com/user-attachments/assets/b554c36c-7b71-4ec3-b7eb-b574ac94beb7">

