### PR TITLE
[YUNIKORN-2923] Fix invalid routerLink setting in header breadcrumb

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -82,7 +82,7 @@
       <div class="breadcrumb-wrapper">
         <ul class="breadcrumb">
           <li *ngFor="let crumb of breadcrumbs">
-            <a href="#" routerLink="crumb.url">{{ crumb.label }}</a>
+            <a href="#" [routerLink]="[crumb.url]">{{ crumb.label }}</a>
           </li>
         </ul>
         <div class="help-menu">


### PR DESCRIPTION
### What is this PR for?
Fixed invalid routerLink setting in header breadcrumb
When click header bearcrumb will navigate to '#/crumb.url' currently.

### What type of PR is it?
* [x] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2923

### Screenshots (if appropriate)
| Before | After | 
|  ----  | ----  |
| <video src="https://github.com/user-attachments/assets/b755e714-9b71-45b3-9130-1aa27f5bbcd0"> | <video src="https://github.com/user-attachments/assets/a6b0d844-8fd7-4443-a9b5-a90a29e5efbf"> | 


