### PR TITLE
[YUNIKORN-2935] Only show children when the queueNode actually has children

### DIFF
--- a/src/app/components/queue-v2/queues-v2.component.ts
+++ b/src/app/components/queue-v2/queues-v2.component.ts
@@ -309,10 +309,13 @@ function queueVisualization(rawData : QueueInfo , componentInstance: QueueV2Comp
         .attr("pointer-events", "none")
         .style("visibility", "hidden");
       
-      group.on("mouseover", function() {
-        plusCircle.style("visibility", "visible");
-        plusText.style("visibility", "visible");
-      });
+      if (d.children) {
+        group.on("mouseover", function() {
+          plusCircle.style("visibility", "visible");
+          plusText.style("visibility", "visible");
+        });
+      }
+      
 
       group.on("click", function() {
         if(selectedNode == this || selectedNode == null){


### PR DESCRIPTION
### What is this PR for?
Only show children when the queueNode actually has children

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-2935](https://issues.apache.org/jira/browse/YUNIKORN-2935)

### Before
There are no children, but we still allow users to click the collapse button.
<img width="1259" alt="before" src="https://github.com/user-attachments/assets/7a8c3162-0d21-43c8-956c-13801646bd6d">


### After
No more collapse button when queue nodes don't have children.
<img width="1244" alt="after" src="https://github.com/user-attachments/assets/fda3a4aa-dbb0-4634-bc1e-7476b1edf6f0">


