### PR TITLE
[YUNIKORN-2949] Load external Scheduler Service using Module Federation

### DIFF
--- a/src/app/components/apps-view/apps-view.component.spec.ts
+++ b/src/app/components/apps-view/apps-view.component.spec.ts
@@ -39,11 +39,13 @@ import {
   MockEnvconfigService,
   MockNgxSpinnerService,
   MockSchedulerService,
+  MockSchedulerServiceLoader,
 } from '@app/testing/mocks';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { of } from 'rxjs';
 
 import { AppsViewComponent } from './apps-view.component';
+import { SchedulerServiceLoader } from '@app/services/scheduler/scheduler-loader.service';
 
 describe('AppsViewComponent', () => {
   let component: AppsViewComponent;
@@ -68,6 +70,7 @@ describe('AppsViewComponent', () => {
       ],
       providers: [
         { provide: SchedulerService, useValue: MockSchedulerService },
+        { provide: SchedulerServiceLoader, useValue: MockSchedulerServiceLoader },
         { provide: NgxSpinnerService, useValue: MockNgxSpinnerService },
         { provide: HAMMER_LOADER, useValue: () => new Promise(() => {}) },
         { provide: EnvconfigService, useValue: MockEnvconfigService },
@@ -112,6 +115,36 @@ describe('AppsViewComponent', () => {
       debugEl.query(By.css('[data-test="Memory: 0.0 bytes,CPU: 0,pods: n/a"]')).nativeElement
         .innerText
     ).toContain('Memory: 0.0 bytes\nCPU: 0');
+  });
+
+  it('should have usedResource and pendingResource column with detailToggle ON', () => {
+    let service: SchedulerService;
+    service = TestBed.inject(SchedulerService);
+    let appInfo = new AppInfo(
+      'app1',
+      'Memory: 500.0 KB, CPU: 10, pods: 1',
+      'Memory: 0.0 bytes, CPU: 0, pods: n/a',
+      '',
+      1,
+      2,
+      [],
+      2,
+      'RUNNING',
+      []
+    );
+    spyOn(service, 'fetchAppList').and.returnValue(of([appInfo]));
+    component.fetchAppListForPartitionAndQueue('default', 'root');
+    component.detailToggle = true;
+    fixture.detectChanges();
+    const debugEl: DebugElement = fixture.debugElement;
+    expect(
+      debugEl.query(By.css('[data-test="Memory: 500.0 KB,CPU: 10,pods: 1"]')).nativeElement
+        .innerText
+    ).toContain('Memory: 500.0 KB\nCPU: 10\npods: 1');
+    expect(
+      debugEl.query(By.css('[data-test="Memory: 0.0 bytes,CPU: 0,pods: n/a"]')).nativeElement
+        .innerText
+    ).toContain('Memory: 0.0 bytes\nCPU: 0\npods: n/a');
   });
 
   it('should have usedResource and pendingResource column with detailToggle ON', () => {

--- a/src/app/components/apps-view/apps-view.component.ts
+++ b/src/app/components/apps-view/apps-view.component.ts
@@ -46,6 +46,7 @@ import {
   loadRemoteModule,
   LoadRemoteModuleEsmOptions,
 } from '@angular-architects/module-federation';
+import { SchedulerServiceLoader } from '@app/services/scheduler/scheduler-loader.service';
 
 @Component({
   selector: 'app-applications-view',
@@ -86,6 +87,7 @@ export class AppsViewComponent implements OnInit {
   allocationsDrawerComponent: ComponentRef<AllocationsDrawerComponent> | undefined = undefined;
 
   constructor(
+    private schedulerServiceLoader: SchedulerServiceLoader,
     private scheduler: SchedulerService,
     private spinner: NgxSpinnerService,
     private activatedRoute: ActivatedRoute,
@@ -93,7 +95,7 @@ export class AppsViewComponent implements OnInit {
     private envConfig: EnvconfigService
   ) {}
 
-  ngOnInit() {
+  async ngOnInit() {
     this.appDataSource.paginator = this.appPaginator;
     this.allocDataSource.paginator = this.allocPaginator;
     this.appDataSource.sort = this.appSort;
@@ -145,6 +147,13 @@ export class AppsViewComponent implements OnInit {
     ];
 
     this.allocColumnIds = this.allocColumnDef.map((col) => col.colId);
+
+    const remoteConfig = this.envConfig.getSchedulerServiceRemoteConfig();
+    if (remoteConfig !== null) {
+      const remoteScheduler =
+        await this.schedulerServiceLoader.initializeSchedulerService(remoteConfig);
+      this.scheduler = remoteScheduler ? remoteScheduler : this.scheduler;
+    }
 
     fromEvent(this.searchInput.nativeElement, 'keyup')
       .pipe(debounceTime(500), distinctUntilChanged())
@@ -265,6 +274,7 @@ export class AppsViewComponent implements OnInit {
   ) {
     this.spinner.show();
 
+    console.log(this.scheduler);
     this.scheduler
       .fetchAppList(partitionName, queueName)
       .pipe(

--- a/src/app/services/envconfig/envconfig.service.ts
+++ b/src/app/services/envconfig/envconfig.service.ts
@@ -76,4 +76,16 @@ export class EnvconfigService {
       };
     return null;
   }
+
+  getSchedulerServiceRemoteConfig(): LoadRemoteModuleEsmOptions | null {
+    if (this.envConfig.schedulerServiceRemote && this.envConfig.moduleFederationRemoteEntry) {
+      return {
+        type: 'module',
+        remoteEntry: this.envConfig.moduleFederationRemoteEntry,
+        exposedModule: this.envConfig.schedulerServiceRemote,
+      };
+    }
+    return null;
+  }
+  
 }

--- a/src/app/services/scheduler/scheduler-loader.service.spec.ts
+++ b/src/app/services/scheduler/scheduler-loader.service.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import * as mf from '@angular-architects/module-federation';
+import { LoadRemoteModuleEsmOptions } from '@angular-architects/module-federation';
+import { SchedulerServiceLoader } from './scheduler-loader.service';
+import { MockEnvconfigService, MockModuleFederationService } from '@app/testing/mocks';
+import { EnvconfigService } from '@app/services/envconfig/envconfig.service';
+import { ModuleFederationWrapper } from '@app/utils/moduleFederationWrapper';
+
+describe('SchedulerServiceLoader', () => {
+  let serviceLoader: SchedulerServiceLoader;
+  let injector: Injector;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SchedulerServiceLoader,
+        { provide: EnvconfigService, useValue: MockEnvconfigService },
+        { provide: mf, useValue: MockModuleFederationService },
+      ],
+    });
+    serviceLoader = TestBed.inject(SchedulerServiceLoader);
+    injector = TestBed.inject(Injector);
+  });
+
+  it('should be created', () => {
+    expect(serviceLoader).toBeTruthy();
+  });
+
+  it('should return null if remoteComponentConfig is null', async () => {
+    const result = await serviceLoader.initializeSchedulerService(null);
+    expect(result).toBeNull();
+  });
+
+  it('should load remote module and return SchedulerService instance', async () => {
+    const loadRemoteModuleOptions: LoadRemoteModuleEsmOptions = {
+      type: 'module',
+      remoteEntry: 'http://localhost/remoteEntry.js',
+      exposedModule: './Module',
+    };
+
+    const fakeModule: any = {};
+    const remoteModule: any = {
+      NewsModule: fakeModule,
+    };
+
+    const mockLoadRemoteModule = spyOn(ModuleFederationWrapper, 'loadRemoteModule');
+
+    mockLoadRemoteModule
+      .withArgs(loadRemoteModuleOptions)
+      .and.returnValue(Promise.resolve(remoteModule));
+
+    const result = await mockLoadRemoteModule(loadRemoteModuleOptions);
+
+    expect(mockLoadRemoteModule).toHaveBeenCalledOnceWith(loadRemoteModuleOptions);
+    expect(result).toEqual(remoteModule);
+  });
+
+  it('should return null and log error if SchedulerService is not found in remote module', async () => {
+    spyOn(console, 'error');
+    spyOn(ModuleFederationWrapper, 'loadRemoteModule').and.returnValue(Promise.resolve({}));
+
+    const remoteComponentConfig = {
+      type: 'module',
+      remoteEntry: 'http://localhost/remoteEntry.js',
+      exposedModule: './Module',
+    } as LoadRemoteModuleEsmOptions;
+    const result = await serviceLoader.initializeSchedulerService(remoteComponentConfig);
+
+    expect(ModuleFederationWrapper.loadRemoteModule).toHaveBeenCalledWith(remoteComponentConfig);
+    expect(console.error).toHaveBeenCalledWith('SchedulerService not found.');
+    expect(result).toBeNull();
+  });
+
+  it('should return null and log error if loading remote module fails', async () => {
+    spyOn(console, 'error');
+    spyOn(ModuleFederationWrapper, 'loadRemoteModule').and.returnValue(
+      Promise.reject(new Error('Loading error'))
+    );
+
+    const remoteComponentConfig = {
+      type: 'module',
+      remoteEntry: 'http://localhost/remoteEntry.js',
+      exposedModule: './Module',
+    } as LoadRemoteModuleEsmOptions;
+
+    const result = await serviceLoader.initializeSchedulerService(remoteComponentConfig);
+
+    expect(ModuleFederationWrapper.loadRemoteModule).toHaveBeenCalledWith(remoteComponentConfig);
+    expect(console.error).toHaveBeenCalledWith(
+      'Error loading the remote module:',
+      new Error('Loading error')
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/services/scheduler/scheduler-loader.service.ts
+++ b/src/app/services/scheduler/scheduler-loader.service.ts
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable, Injector } from '@angular/core';
+import { LoadRemoteModuleEsmOptions } from '@angular-architects/module-federation';
+import { SchedulerService } from './scheduler.service';
+import { ModuleFederationWrapper } from '@app/utils/moduleFederationWrapper';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SchedulerServiceLoader {
+  constructor(private injector: Injector) {}
+
+  async initializeSchedulerService(
+    remoteComponentConfig: LoadRemoteModuleEsmOptions | null
+  ): Promise<SchedulerService | null> {
+    if (remoteComponentConfig !== null) {
+      try {
+        const remoteModule = await ModuleFederationWrapper.loadRemoteModule(remoteComponentConfig);
+        if (remoteModule && remoteModule.SchedulerService) {
+          return this.injector.get(remoteModule.SchedulerService);
+        } else {
+          return null;
+        }
+      } catch (error) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/src/app/testing/mocks.ts
+++ b/src/app/testing/mocks.ts
@@ -17,11 +17,15 @@
  */
 
 import { of } from 'rxjs';
-import { AppInfo } from '@app/models/app-info.model';
-import { CommonUtil } from '@app/utils/common.util';
+import { LoadRemoteModuleEsmOptions } from '@angular-architects/module-federation';
+import { SchedulerServiceLoader } from '@app/services/scheduler/scheduler-loader.service';
 
 export const noopFn = () => {};
 export const nullFn = () => null;
+
+export const MockModuleFederationService = {
+  loadRemoteModule: (config: LoadRemoteModuleEsmOptions) => of({}),
+};
 
 export const MockSchedulerService = {
   fetchClusterByName: () => of({}),
@@ -43,9 +47,22 @@ export const MockNgxSpinnerService = {
 export const MockEnvconfigService = {
   getSchedulerWebAddress: noopFn,
   getAllocationsDrawerComponentRemoteConfig: nullFn,
+  getSchedulerServiceRemoteConfig: nullFn,
 };
 
 export const MockEventBusService = {
   getEvent: () => of<any>(),
   publish: noopFn,
+};
+
+export const MockSchedulerServiceLoader = {
+  loadScheduler: () => of(MockSchedulerService),
+  initializeSchedulerService: () => of(MockSchedulerService),
+  fetchClusterByName: () => of({}),
+  fetchClusterList: () => of([]),
+  fetchPartitionList: () => of([]),
+  fetchSchedulerQueues: () => of({}),
+  fetchAppList: () => of([]),
+  fetchAppHistory: () => of([]),
+  fetchContainerHistory: () => of([]),
 };

--- a/src/app/utils/moduleFederationWrapper.ts
+++ b/src/app/utils/moduleFederationWrapper.ts
@@ -16,9 +16,14 @@
  * limitations under the License.
  */
 
-export interface EnvConfig {
-  localSchedulerWebAddress: string;
-  moduleFederationRemoteEntry?: string;
-  allocationsDrawerRemoteComponent?: string;
-  schedulerServiceRemote?: string;
-}
+import { loadRemoteModule, LoadRemoteModuleOptions } from '@angular-architects/module-federation';
+
+/**
+ * ModuleFederationWrapper is a utility class that wraps the loadRemoteModule function from the @angular-architects/module-federation package.
+ * This allows Jasmine to spy on the loadRemoteModule function
+ */
+export const ModuleFederationWrapper = {
+  loadRemoteModule<T = any>(options: LoadRemoteModuleOptions): Promise<T> {
+    return loadRemoteModule<T>(options);
+  },
+};

--- a/src/assets/config/envconfig.json
+++ b/src/assets/config/envconfig.json
@@ -1,5 +1,6 @@
 {
   "localSchedulerWebAddress": "http://localhost:9889",
   "moduleFederationRemoteEntry": "",
-  "allocationsDrawerRemoteComponent": ""
+  "allocationsDrawerRemoteComponent": "",
+  "schedulerServiceRemote": ""
 }


### PR DESCRIPTION
### What is this PR for?
This will allow using the remote Scheduler Service to load the data into YuniKorn Web. The idea is to use an existing federated sidebar in combination with a custom service method to pull and display the data from the YHS ([YuniKorn History Server](https://github.com/g-Research/yunikorn-history-server/)) 


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2949](https://issues.apache.org/jira/browse/YUNIKORN-2949)

### How should this be tested?
Pull the [YHS repository](https://github.com/g-Research/yunikorn-history-server/) and enter the Web folder. Start the application and on the index page, it will render environment variables that should be set in the YHS. There will be no visible changes in the app behavior as the YHS is still in the pre-alpha stage of development, but the network tab might show that there was a package loaded from the YHS address

