### PR TITLE
[YUNIKORN-2956] Fix layout break on Queues v2 page

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+$header-height: 60px;
+
 .navigation {
   position: fixed;
   width: 50px;
@@ -68,7 +70,7 @@
   white-space: nowrap;
   color: #fff;
   background: #313d54;
-  height: 60px;
+  height: $header-height;
   overflow: hidden;
   -webkit-transition: padding-left 0.4s ease, padding-top 0.4s ease;
   -moz-transition: padding-left 0.4s ease, padding-top 0.4s ease;
@@ -229,7 +231,7 @@ ul.navigation-primary {
 }
 
 .container-fluid {
-  padding-top: 58px;
+  padding-top: $header-height;
 }
 
 //  remove the beta tag when the feature is ready for production
@@ -240,7 +242,7 @@ ul.navigation-primary {
 }
 
 .header {
-  height: 58px;
+  height: $header-height;
   background: #fff;
   padding: 0 20px;
   border-bottom: 1px solid #e3e3e3;
@@ -316,4 +318,5 @@ ul.breadcrumb a.back:after {
 
 .content-wrapper {
   padding: 20px;
+  height: calc(100vh - $header-height);
 }

--- a/src/app/components/apps-view/apps-view.component.scss
+++ b/src/app/components/apps-view/apps-view.component.scss
@@ -19,7 +19,6 @@
 
 .top-section {
   width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/app/components/nodes-view/nodes-view.component.scss
+++ b/src/app/components/nodes-view/nodes-view.component.scss
@@ -68,7 +68,6 @@
 
 .nodes-view {
   width: 100%;
-  height: 100%;
   .mat-mdc-header-cell {
     font-size: 15px;
     font-weight: 500;

--- a/src/app/components/queue-v2/queues-v2.component.scss
+++ b/src/app/components/queue-v2/queues-v2.component.scss
@@ -16,13 +16,20 @@
  * limitations under the License.
  */
 
+ .queue-container {
+    height: 100%;
+ }
+
  .queue-content-box {
     width: calc(100% - 2rem); /* Subtract padding from the total width */
-    height: calc(100vh - 2rem); /* Subtract padding from the total height to ensure it's nearly as tall as the container */
+    height: 100%;
     border-radius: 0.5rem;
     background-color: white;
     padding: 20px; /* Adjust padding to your preference */
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+
+    display: flex;
+    flex-direction: column;
   }
   
   .header .title-group {
@@ -120,8 +127,13 @@
       background-color: #8090a5;
   }
 
+  .body {
+    height: 100%;
+  }
+
   .content-wrapper {
     display: flex;
+    height: 100%;
   }
 
   .visualize-area {
@@ -129,8 +141,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 600px; 
-    max-height: 80%; /* Ensure there's space around the area within the content box */
+    height: 100%; 
     width: 100%;
     border-radius: 0.5rem;
     border: 2px dashed #d1d5db;


### PR DESCRIPTION
### What is this PR for?
Queues v2 page layout not expected fit content in panel when media screen height small.
It will overflow the panel block.

### What type of PR is it?
* [x] - Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2956

### Screenshots (if appropriate)


| Before | After |
|  ----  | ----  |
|   <img width="1165" alt="yinikorn-queues-v2" src="https://github.com/user-attachments/assets/478b89e3-a3cd-49ae-a55b-0c87f87dcc5a">   | <img width="1167" alt="yinikorn-queues-v2-after" src="https://github.com/user-attachments/assets/0aa926a8-def5-42db-b667-5875c4247411"> |


