### PR TITLE
[YUNIKORN-2970] Don't display node attributes by default on the node view page

### DIFF
--- a/src/app/components/nodes-view/nodes-view.component.ts
+++ b/src/app/components/nodes-view/nodes-view.component.ts
@@ -90,7 +90,10 @@ export class NodesViewComponent implements OnInit {
       },
     ];
 
-    this.nodeColumnIds = this.nodeColumnDef.map((col) => col.colId).concat('indicatorIcon');
+    this.nodeColumnIds = this.nodeColumnDef
+      .filter(col=> !['attributes'].includes(col.colId))
+      .map((col) => col.colId)
+      .concat('indicatorIcon');
 
     this.allocColumnDef = [
       { colId: 'displayName', colName: 'Display Name' },


### PR DESCRIPTION
### What is this PR for?
Don't display node attributes by default on the node view UI
Fix duplicated attributes column when first click expend more button

### What type of PR is it?
* [x] - Bug Fix
* [x] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2970




### Screenshots (if appropriate)
| Before | After | 
|  ----  | ----  |
| <video src="https://github.com/user-attachments/assets/dcfa97c7-430c-4145-85e8-eba2ae98b185"> | <video src="https://github.com/user-attachments/assets/6c4b5550-a5c2-4867-83dc-6c0af0f87ef5"> | 



