### PR TITLE
[YUNIKORN-2987] Remove -installsuffix switch during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,13 +296,13 @@ ifeq ($(REPRO),1)
 	CGO_ENABLED=0 GOOS=linux GOARCH=\"${EXEC_ARCH}\" \
 	go build -a -o=${RELEASE_BIN_DIR}/${SERVER_BINARY} -trimpath -ldflags \
 	'-buildid= -extldflags \"-static\" -X main.version=${VERSION} -X main.date=${DATE}' \
-	-tags netgo -installsuffix netgo \
+	-tags netgo \
 	./pkg/cmd/web/"
 else
 	CGO_ENABLED=0 GOOS=linux GOARCH="${EXEC_ARCH}" \
 	"$(GO)" build -a -o=${RELEASE_BIN_DIR}/${SERVER_BINARY} -trimpath -ldflags \
 	'-buildid= -extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
-	-tags netgo -installsuffix netgo \
+	-tags netgo \
 	./pkg/cmd/web/
 endif
 


### PR DESCRIPTION
### What is this PR for?
Remove the `-installsuffix` switch for `go build`. It used to be a workaround, but no longer needed.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2985

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
