### PR TITLE
[YUNIKORN-2993] Use empty array when `stateLog` not exists for `AppInfo`

### DIFF
--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -96,7 +96,7 @@ export class SchedulerService {
               this.formatResource(app['maxUsedResource'] as SchedulerResourceInfo),
               app['submissionTime'],
               app['lastStateChangeTime'],
-              app['stateLog'],
+              app['stateLog'] ?? [],
               app['finishedTime'],
               app['applicationState'],
               []


### PR DESCRIPTION
### What is this PR for?

When `stateLog` does not exist for some application returned by API `/ws/v1/partition/${partitionName}/queue/${queueName}/applications`, calling `appInfo.setLastStateChangeTime()` would trigger the following error:

```
TypeError: Cannot read properties of undefined (reading 'forEach')
    at wne.setLastStateChangeTime (main.ec6040d2f2dbf6bb.js:1:775934)
```

We should fall back to empty array for `AppInfo.stateLog` when it doesn't exist in the API response.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?

YUNIKORN-2993

### How should this be tested?

Manual

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
