### PR TITLE
[YUNIKORN-3071] Disable queue UI v2 for release 1.7

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -36,6 +36,7 @@
         <span *ngIf="isNavOpen">Queues</span>
       </a>
     </li>
+    <!--
     <li routerLinkActive="active">
       <a routerLink="/queues-v2">
         <i class="fa fa-sitemap" style="width: 16px"></i>
@@ -46,6 +47,7 @@
         </div> 
       </a>
     </li>
+    -->
     <li routerLinkActive="active">
       <a routerLink="/applications">
         <i class="fa fa-indent text-center"></i>


### PR DESCRIPTION
### What is this PR for?
Hide the link to the new UI. Does not remove the new UI code which can still be accessed at /queues-v2 by removing the comment
Change for branch 1.7 only

### What type of PR is it?
* [X] - Feature removal

### What is the Jira issue?
* [YUNIKORN-3071](https://issues.apache.org/jira/browse/YUNIKORN-3071)

### How should this be tested?
The web UI should not show the 2nd queue link