### PR TITLE
[YUNIKORN-3076] WebUI fails to load apps that are in 'New' state and …

### DIFF
--- a/src/app/components/apps-view/apps-view.component.spec.ts
+++ b/src/app/components/apps-view/apps-view.component.spec.ts
@@ -30,7 +30,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { By, HAMMER_LOADER } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { AppInfo } from '@app/models/app-info.model';
+import { AppInfo, StateLog } from '@app/models/app-info.model';
 import { SchedulerService } from '@app/services/scheduler/scheduler.service';
 import { MockNgxSpinnerService, MockSchedulerService } from '@app/testing/mocks';
 import { NgxSpinnerService } from 'ngx-spinner';
@@ -107,5 +107,48 @@ describe('AppsViewComponent', () => {
     const copyButtonSpy = spyOn(component, 'copyLinkToClipboard');
     copyButton.triggerEventHandler('click', null);
     expect(copyButtonSpy).toHaveBeenCalled();
+  });
+
+  it('should set lastStateChangeTime to the latest time in stateLog', () => {
+    const stateLogs = [
+      new StateLog(100, 'SUBMITTED'),
+      new StateLog(200, 'RUNNING'),
+      new StateLog(300, 'FINISHED')
+    ];
+    const appInfo = new AppInfo(
+      'app-test',
+      'Memory: 10.0 MB, CPU: 1, pods: 1',
+      'Memory: 0.0 bytes, CPU: 0, pods: n/a',
+      '',
+      123,
+      null,
+      stateLogs,
+      null,
+      'FINISHED',
+      []
+    );
+
+    appInfo.setLastStateChangeTime();
+
+    expect(appInfo.lastStateChangeTime).toBe(300);
+  });
+
+  it('should set lastStateChangeTime to 0 if stateLog is empty', () => {
+    const appInfo = new AppInfo(
+      'app-empty',
+      'Memory: 10.0 MB, CPU: 1, pods: 1',
+      'Memory: 0.0 bytes, CPU: 0, pods: n/a',
+      '',
+      123,
+      null,
+      [],
+      null,
+      'SUBMITTED',
+      []
+    );
+
+    appInfo.setLastStateChangeTime();
+
+    expect(appInfo.lastStateChangeTime).toBe(0);
   });
 });

--- a/src/app/models/app-info.model.ts
+++ b/src/app/models/app-info.model.ts
@@ -30,11 +30,16 @@ export class AppInfo {
     public maxUsedResource: string,
     public submissionTime: number,
     public finishedTime: null | number,
-    public stateLog: Array<StateLog>,
+    public stateLog: Array<StateLog> = [], // Default to empty array
     public lastStateChangeTime: null | number,
     public applicationState: string,
     public allocations: AllocationInfo[] | null
-  ) {}
+  ) {
+    // Ensure stateLog is always an array
+    if (!Array.isArray(this.stateLog)) {
+      this.stateLog = [];
+    }
+  }
 
   get formattedSubmissionTime() {
     const millisecs = Math.round(this.submissionTime / (1000 * 1000));


### PR DESCRIPTION
…does not have stateLog

### What is this PR for?

This pull request addresses an issue in the web UI where the absence of a stateLog object for applications in the 'New' state causes the page to fail loading the list of applications. By setting a default value for the stateLog object and ensuring it is an Array object, we ensure that the application list can be loaded and displayed correctly, even when some applications are in the 'New' state without a stateLog.

**Issue:**
When an application is reported to be in a 'New' state by the scheduler, it does not have a stateLog object. On the web UI side, there are currently no checks to handle the absence of the stateLog object. As a result, when the application list contains an application in the 'New' state and the stateLog is missing, the code attempts to access this.stateLog, leading to a failure and preventing the page from loading any applications.

This behavior has been observed on clusters with heavy load.


### What type of PR is it?
* [X] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-3076

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
