### PR TITLE
[YUNIKORN-3302] turn off web UI v2

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -40,6 +40,8 @@
         }
       </a>
     </li>
+<!--
+    New web UI link turned off by default via YUNIKORN-3302
     <li routerLinkActive="active">
       <a routerLink="/queues-v2">
         <i class="fa fa-sitemap" style="width: 16px"></i>
@@ -54,6 +56,7 @@
         }
       </a>
     </li>
+-->
     <li routerLinkActive="active">
       <a routerLink="/applications">
         <i class="fa fa-indent text-center"></i>


### PR DESCRIPTION
### What is this PR for?
Web UI v2 has development has stalled, turning off the new web UI in master for now until we have a more mature UI to show.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* Jira https://issues.apache.org/jira/browse/YUNIKORN-3302

### How should this be tested?
The web UI should no longer show the queue V2 link
